### PR TITLE
Template database and new ns_ options

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -1,0 +1,44 @@
+name: apidocs
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+
+    - name: Install requirements for documentation generation
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install docutils pydoctor
+
+    - name: Generate API documentation with pydoctor
+      run: |
+
+        # Run pydoctor build
+        pydoctor \
+            --project-name=python3-nethsec \
+            --project-url=https://github.com/$GITHUB_REPOSITORY \
+            --html-viewsource-base=https://github.com/$GITHUB_REPOSITORY/tree/$GITHUB_SHA \
+            --make-html \
+            --html-output=./apidocs \
+            --project-base-dir="$(pwd)" \
+            --docformat=restructuredtext \
+            --intersphinx=https://docs.python.org/3/objects.inv \
+            ./src/nethsec
+
+    - name: Push API documentation to Github Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./apidocs
+        commit_message: "Generate API documentation"

--- a/README.md
+++ b/README.md
@@ -29,8 +29,28 @@ firewall.apply(u)
 
 ## Documentation
 
-Execute:
+Documentation can be generated using [pydoctor](https://pydoctor.readthedocs.io) or [pydoc](https://docs.python.org/3/library/pydoc.html).
+
+Documentation is automatically generated at each new commit on master branch.
+Online doc is hosted on [GitHub pages](https://nethserver.github.io/python3-nethsec).
+
+Generate doc using pydoctor:
+```
+pip install -U pydoctor
+pydoctor  \
+  --project-name=python3-nethsec \
+  --project-url=https://github.com/nethserver/python3-nethsec \
+  --make-html \
+  --html-output=./apidocs \
+  --project-base-dir="$(pwd)" \
+  --docformat=restructuredtext \
+  --intersphinx=https://docs.python.org/3/objects.inv \
+  ./src/nethsec
+```
+
+Generate doc using pydoc:
 ```bash
+cd src
 python3 -m pydoc nethsec.firewall
 python3 -m pydoc nethsec.utils
 ```

--- a/src/nethsec/firewall/__init__.py
+++ b/src/nethsec/firewall/__init__.py
@@ -248,19 +248,19 @@ def apply(uci):
     subprocess.run(["/etc/init.d/firewall", "reload"], check=True)
 
 
-def add_default_forwarding(uci, name):
+def add_template_forwarding(uci, name):
     '''
-    Create a forwarding from ns-api default database.
+    Create a forwarding from templates database.
 
     Arguments:
       - uci -- EUci pointer
-      - name -- Name of the default forwarding from the ns-api database
+      - name -- Name of the template forwarding from the templates database
 
     Returns a tuple:
       - The name of the configuration section for the forwarding or None in case of error
     '''
 
-    frecord =  uci.get_all("ns-api", name)
+    frecord =  uci.get_all("templates", name)
     fname = utils.get_random_id()
     uci.set("firewall", fname, "forwarding")
     for section in frecord:
@@ -269,13 +269,13 @@ def add_default_forwarding(uci, name):
 
     return fname
 
-def add_default_zone(uci, name, networks = []):
+def add_template_zone(uci, name, networks = []):
     '''
-    Create a zone from ns-api default database.
+    Create a zone from templates database.
 
     Arguments:
       - uci -- EUci pointer
-      - name -- Name of the default zone from the ns-api database
+      - name -- Name of the zone from the templates database
       - network -- A list of interfaces to be added to the zone (optional)
 
     Returns a tuple:
@@ -283,7 +283,7 @@ def add_default_zone(uci, name, networks = []):
       - A list of configuration section names for the forwardings or None in case of error
     '''
 
-    dzone = uci.get_all("ns-api", name)
+    dzone = uci.get_all("templates", name)
     # Search for zones with the same "name"
     for zone in utils.get_all_by_type(uci, "firewall", "zone"):
         if uci.get("firewall", zone, "name") == dzone["name"]:
@@ -300,17 +300,17 @@ def add_default_zone(uci, name, networks = []):
     uci.set("firewall", zname, "ns_tag", ["automated"])
 
     for forward in forward_list:
-        forwardings.append(add_default_forwarding(uci, forward))
+        forwardings.append(add_template_forwarding(uci, forward))
 
     return (zname, forwardings)
 
-def add_default_service_group(uci, name, src='lan', dest='wan', link=""):
+def add_template_service_group(uci, name, src='lan', dest='wan', link=""):
     '''
     Create all rules for the given service group
 
     Arguments:
       - uci -- EUci pointer
-      - name -- Name of the default service group from the ns-api database
+      - name -- Name of the service group from the templates database
       - src -- Source zone, default is 'lan'. The zone must already exists inside the firewall db
       - dest -- Destination zone, default is 'wan'. The zone must already exists inside the firewall db
       - link -- A reference to an existing key in the format <database>/<keyname> (optional)
@@ -319,7 +319,7 @@ def add_default_service_group(uci, name, src='lan', dest='wan', link=""):
       - A list of configuration section names of each rule, None in case of error
     '''
 
-    group = uci.get_all("ns-api", name)
+    group = uci.get_all("templates", name)
     services = group.pop("services", list())
 
     if not services:
@@ -354,13 +354,13 @@ def add_default_service_group(uci, name, src='lan', dest='wan', link=""):
 
     return sections
 
-def add_default_rule(uci, name, proto, port, link=""):
+def add_template_rule(uci, name, proto, port, link=""):
     '''
-    Create a rule from ns-api default database.
+    Create a rule from templates database.
 
     Arguments:
       - uci -- EUci pointer
-      - name -- Name of the default rule from the ns-api database
+      - name -- Name of the template rule from the templates database
       - proto -- A valid UCI protocol
       - ports -- A port or comma-separated list of ports
       - link -- A reference to an existing key in the format <database>/<keyname> (optional)
@@ -369,7 +369,7 @@ def add_default_rule(uci, name, proto, port, link=""):
       - The name of the configuration section for the rule or None in case of error
     '''
 
-    drule = uci.get_all("ns-api", name)
+    drule = uci.get_all("templates", name)
     rname = utils.get_random_id()
     uci.set("firewall", rname, "rule")
     for section in drule:
@@ -384,7 +384,7 @@ def add_default_rule(uci, name, proto, port, link=""):
 
 def get_all_linked(uci, link):
     '''
-    Search all database, execpt ns-api one, for entities with the given link
+    Search all database, execpt templates one, for entities with the given link
 
     Arguments:
       - uci -- EUci pointer
@@ -397,7 +397,7 @@ def get_all_linked(uci, link):
 
     ret = dict()
     for config in uci.list_configs():
-        if config == "ns-api":
+        if config == "templates":
             continue
         records = utils.get_all_by_option(uci, config, 'ns_link', link, deep = False)
         ret[config] = records

--- a/src/nethsec/firewall/__init__.py
+++ b/src/nethsec/firewall/__init__.py
@@ -137,7 +137,7 @@ def add_trusted_zone(uci, name, networks = []):
 
 def add_service(uci, name, port, proto):
     '''
-    Create an ACCEPT traffic rile for the given service
+    Create an ACCEPT traffic rule for the given service
 
     Arguments:
       uci -- EUci pointer

--- a/src/nethsec/firewall/__init__.py
+++ b/src/nethsec/firewall/__init__.py
@@ -19,13 +19,13 @@ def add_to_zone(uci, device, zone):
     The device is not added if the firewall zone does not exists
 
     Arguments:
-      uci -- EUci pointer
-      device -- Device name
-      zone -- Firewall zone name
+      - uci -- EUci pointer
+      - device -- Device name
+      - zone -- Firewall zone name
 
     Returns:
-      If the firewall zone exists, the name of the section where the device has been added.
-      None, otherwise.
+      - If the firewall zone exists, the name of the section where the device has been added.
+      - None, otherwise.
     '''
     for section in uci.get("firewall"):
         s_type = uci.get("firewall", section)
@@ -48,11 +48,11 @@ def add_to_lan(uci, device):
     Shortuct to add a device to lan zone
 
     Arguments:
-      uci -- EUci pointer
-      device -- Device name
+      - uci -- EUci pointer
+      - device -- Device name
 
     Returns:
-      The name of section or None
+      - The name of section or None
     '''
     return add_to_zone(uci, device, 'lan')
 
@@ -61,11 +61,11 @@ def add_to_wan(uci, device):
     Shortuct to add a device to wan zone
 
     Arguments:
-      uci -- EUci pointer
-      device -- Device name
+      - uci -- EUci pointer
+      - device -- Device name
 
     Returns:
-      The name of the configuration section or None
+      - The name of the configuration section or None
     '''
     return add_to_zone(uci, device, 'wan')
 
@@ -76,13 +76,13 @@ def add_vpn_interface(uci, name, device, link=""):
     This function automatically commits the network database.
 
     Arguments:
-      uci -- EUci pointer
-      name -- Interface name
-      device -- Device name
-      link -- A reference to an existing key in the format <database>/<keyname> (optional)
+      - uci -- EUci pointer
+      - name -- Interface name
+      - device -- Device name
+      - link -- A reference to an existing key in the format <database>/<keyname> (optional)
 
     Returns:
-      The name of the configuration section or None in case of error
+      - The name of the configuration section or None in case of error
     '''
     iname = utils.sanitize(name)
     uci.set('network', iname, 'interface')
@@ -97,14 +97,14 @@ def add_vpn_interface(uci, name, device, link=""):
 def add_trusted_zone(uci, name, networks = [], link = ""):
     '''
     Create a trusted zone. The zone will:
-    - be able to access lan and wan zone
-    - be accessible from lan zone
+      - be able to access lan and wan zone
+      - be accessible from lan zone
 
     Arguments:
-      uci -- EUci pointer
-      name -- Zone name, maximum length is 12
-      network -- A list of interfaces to be added to the zone (optional)
-      link -- A reference to an existing key in the format <database>/<keyname> (optional)
+      - uci -- EUci pointer
+      - name -- Zone name, maximum length is 12
+      - network -- A list of interfaces to be added to the zone (optional)
+      - link -- A reference to an existing key in the format <database>/<keyname> (optional)
 
     Returns a tuple:
       - The name of the configuration section or None in case of error
@@ -162,14 +162,14 @@ def add_service(uci, name, port, proto, link = ""):
     Create an ACCEPT traffic rule for the given service
 
     Arguments:
-      uci -- EUci pointer
-      name -- Service name
-      port -- Service port number as string
-      proto -- List of service protocols
-      link -- A reference to an existing key in the format <database>/<keyname> (optional)
+      - uci -- EUci pointer
+      - name -- Service name
+      - port -- Service port number as string
+      - proto -- List of service protocols
+      - link -- A reference to an existing key in the format <database>/<keyname> (optional)
 
     Returns:
-      The name of the configuration section
+      - The name of the configuration section
     '''
     rname = utils.get_id(f"allow_{name}")
     uci.set("firewall", rname, "rule")
@@ -189,11 +189,11 @@ def remove_service(uci, name):
     Remove the ACCEPT traffic rule for the given service
 
     Arguments:
-      uci -- EUci pointer
-      name -- Service name
+      - uci -- EUci pointer
+      - name -- Service name
 
     Returns:
-      The name of the configuration section
+      - The name of the configuration section
     '''
     rname = utils.get_id(f"allow_{name}")
     uci.delete("firewall", rname)
@@ -204,11 +204,11 @@ def disable_service(uci, name):
     Disable the ACCEPT rule traffic for the given service.
 
     Arguments:
-      uci -- EUci pointer
-      name -- Service name
+      - uci -- EUci pointer
+      - name -- Service name
 
     Returns:
-      The name of the configuration section if found, None otherwise
+      - The name of the configuration section if found, None otherwise
     '''
     rname = utils.get_id(f"allow_{name}")
     try:
@@ -222,11 +222,11 @@ def enable_service(uci, name):
     Disable the ACCEPT rule traffic for the given service
 
     Arguments:
-      uci -- EUci pointer
-      name -- Service name
+      - uci -- EUci pointer
+      - name -- Service name
 
     Returns:
-      The name of the configuration section if found, None otherwise
+      - The name of the configuration section if found, None otherwise
     '''
     rname = utils.get_id(f"allow_{name}")
     try:
@@ -238,11 +238,11 @@ def enable_service(uci, name):
 def apply(uci):
     '''
     Apply firewall configuration:
-    - commit changes to firewall config
-    - reload the firewall service
+      - commit changes to firewall config
+      - reload the firewall service
 
     Arguments:
-      uci -- EUci pointer
+      - uci -- EUci pointer
     '''
     uci.commit('firewall')
     subprocess.run(["/etc/init.d/firewall", "reload"], check=True)
@@ -253,8 +253,8 @@ def add_default_forwarding(uci, name):
     Create a forwarding from ns-api default database.
 
     Arguments:
-      uci -- EUci pointer
-      name -- Name of the default forwarding from the ns-api database
+      - uci -- EUci pointer
+      - name -- Name of the default forwarding from the ns-api database
 
     Returns a tuple:
       - The name of the configuration section for the forwarding or None in case of error
@@ -274,9 +274,9 @@ def add_default_zone(uci, name, networks = []):
     Create a zone from ns-api default database.
 
     Arguments:
-      uci -- EUci pointer
-      name -- Name of the default zone from the ns-api database
-      network -- A list of interfaces to be added to the zone (optional)
+      - uci -- EUci pointer
+      - name -- Name of the default zone from the ns-api database
+      - network -- A list of interfaces to be added to the zone (optional)
 
     Returns a tuple:
       - The name of the configuration section for the zone or None in case of error
@@ -309,10 +309,10 @@ def add_default_service_group(uci, name, src='lan', dest='wan'):
     Create all rules for the given service group
 
     Arguments:
-      uci -- EUci pointer
-      name -- Name of the default service group from the ns-api database
-      src -- Source zone, default is 'lan'. The zone must already exists inside the firewall db
-      dest -- Destination zone, default is 'wan'. The zone must already exists inside the firewall db
+      - uci -- EUci pointer
+      - name -- Name of the default service group from the ns-api database
+      - src -- Source zone, default is 'lan'. The zone must already exists inside the firewall db
+      - dest -- Destination zone, default is 'wan'. The zone must already exists inside the firewall db
 
     Returns:
       - A list of configuration section names of each rule, None in case of error
@@ -356,10 +356,10 @@ def add_default_rule(uci, name, proto, port):
     Create a rule from ns-api default database.
 
     Arguments:
-      uci -- EUci pointer
-      name -- Name of the default rule from the ns-api database
-      proto -- A valid UCI protocol
-      ports -- A port or comma-separated list of ports
+      - uci -- EUci pointer
+      - name -- Name of the default rule from the ns-api database
+      - proto -- A valid UCI protocol
+      - ports -- A port or comma-separated list of ports
 
     Returns:
       - The name of the configuration section for the rule or None in case of error

--- a/src/nethsec/utils/__init__.py
+++ b/src/nethsec/utils/__init__.py
@@ -11,7 +11,30 @@ General utilities
 
 import re
 import json
+import uuid
+import hashlib
 import subprocess
+
+def get_random_id():
+    '''
+    Return a random valid UCI id.
+
+    Random ids:
+    - have a length of 11 characters
+    - are sanitized accordingly to UCI conventions (see 'sanitize' function)
+    - start with 'ns_' prefix
+
+    Arguments:
+      name -- the name of the section
+
+    Returns:
+      a valid UCI identifier as string
+    '''
+
+    h = hashlib.new('sha1')
+    h.update(uuid.uuid4().bytes)
+    digest = h.hexdigest()
+    return get_id(digest, 11)
 
 def get_id(name, length = 100):
     '''

--- a/src/nethsec/utils/__init__.py
+++ b/src/nethsec/utils/__init__.py
@@ -153,7 +153,7 @@ def get_interface_from_device(uci, device):
 
     return None
 
-def get_all_by_option(uci, config, option, value):
+def get_all_by_option(uci, config, option, value, deep = True):
     '''
     Return all sections with the given option value
 
@@ -162,15 +162,22 @@ def get_all_by_option(uci, config, option, value):
       - config -- Configuration database name
       - option -- Option name
       - value -- Option value
+      - deep - If true, return a dict of all matched keys, otherwise return a list of section named
 
     Returns:
-      - A dictionary of all matched sections
+      - A dictionary or a list of all matched sections
     '''
     ret = dict()
     for section in uci.get(config, list=True, default=[]):
         if uci.get(config, section, option, default='') == value:
-            ret[section] = uci.get_all(config, section)
-    return ret
+            if deep:
+                ret[section] = uci.get_all(config, section)
+            else:
+                ret[section] = 1
+    if deep:
+        return ret
+    else:
+        return list(ret.keys())
 
 
 def get_all_devices_by_zone(uci, zone):

--- a/src/nethsec/utils/__init__.py
+++ b/src/nethsec/utils/__init__.py
@@ -20,15 +20,15 @@ def get_random_id():
     Return a random valid UCI id.
 
     Random ids:
-    - have a length of 11 characters
-    - are sanitized accordingly to UCI conventions (see 'sanitize' function)
-    - start with 'ns_' prefix
+      - have a length of 11 characters
+      - are sanitized accordingly to UCI conventions (see 'sanitize' function)
+      - start with ns\_ prefix
 
     Arguments:
-      name -- the name of the section
+      - name -- the name of the section
 
     Returns:
-      a valid UCI identifier as string
+      - a valid UCI identifier as string
     '''
 
     h = hashlib.new('sha1')
@@ -40,16 +40,17 @@ def get_id(name, length = 100):
     '''
     Return a valid UCI id based on the given string.
     All auto-generated NethSecurity ids:
-    - have a maximum length of 100 characters
-    - are sanitized accordingly to UCI conventions (see 'sanitize' function)
-    - start with 'ns_' prefix
+
+      - have a maximum length of 100 characters
+      - start with ns\_ prefix
+      - are sanitized accordingly to UCI conventions
 
     Arguments:
-      name -- the name of the section
-      length -- maximum id length, default is 100. Maximum lenght for firewall zones is 15.
+      - name -- the name of the section
+      - length -- maximum id length, default is 100. Maximum lenght for firewall zones is 15.
 
     Returns:
-      a valid UCI identifier as string
+      - a valid UCI identifier as string
     '''
     sname = f'ns_{sanitize(name)}'
     return sname[0:length]
@@ -60,10 +61,10 @@ def sanitize(name):
     UCI identifiers and config file names may contain only the characters a-z, 0-9 and _
 
     Arguments:
-      name -- the name of the section
+      - name -- the name of the section
     
     Returns:
-      a string with valid chachars for UCI
+      - a string with valid chachars for UCI
     '''
     name = re.sub(r'[^\x00-\x7F]+','_', name)
     name = re.sub('[^0-9a-zA-Z]', '_', name)
@@ -74,12 +75,12 @@ def get_all_by_type(uci, config, utype):
     Return all sections of the given utype from the given config
 
     Arguments:
-      uci -- EUci pointer
-      config -- Configuration database name
-      utype -- Section type
+      - uci -- EUci pointer
+      - config -- Configuration database name
+      - utype -- Section type
 
     Returns:
-      A dictionary of all matched sections, None in case of error
+      - A dictionary of all matched sections, None in case of error
     '''
     ret = dict()
     try:
@@ -95,10 +96,10 @@ def get_device_name(hwaddr):
     Retrieve the physical device name given the MAC address
 
     Aarguments:
-      hwaddr -- MAC address string
+      - hwaddr -- MAC address string
 
     Returns:
-      The device name as a string if the network interface has been found, None otherwise.
+      - The device name as a string if the network interface has been found, None otherwise.
     '''
     try:
         interfaces = json.loads(subprocess.run(["/sbin/ip", "--json", "address", "show"], check=True, capture_output=True).stdout)
@@ -115,11 +116,11 @@ def get_interface_from_mac(uci, hwaddr):
     Retrieve the logical UCI interface name given the MAC address
 
     Arguments:
-      uci -- EUci pointer
-      hwaddr -- MAC address string
+      - uci -- EUci pointer
+      - hwaddr -- MAC address string
 
     Returns:
-      The device name as a string if the interface has been found, None otherwise
+      - The device name as a string if the interface has been found, None otherwise
     '''
     device = get_device_name(hwaddr)
     return get_interface_from_device(uci, device)
@@ -129,11 +130,11 @@ def get_interface_from_device(uci, device):
     Retrieve the logical UCI interface name given the device name
 
     Arguments:
-      uci -- EUci pointer
-      hwaddr -- MAC address string
+      - uci -- EUci pointer
+      - hwaddr -- MAC address string
 
     Returns:
-      The device name as a string if the interface has been found, None otherwise
+      - The device name as a string if the interface has been found, None otherwise
     '''
     for section in uci.get("network"):
         if uci.get("network", section) == "interface":
@@ -157,13 +158,13 @@ def get_all_by_option(uci, config, option, value):
     Return all sections with the given option value
 
     Arguments:
-      uci -- EUci pointer
-      config -- Configuration database name
-      option -- Option name
-      value -- Option value
+      - uci -- EUci pointer
+      - config -- Configuration database name
+      - option -- Option name
+      - value -- Option value
 
     Returns:
-      A dictionary of all matched sections
+      - A dictionary of all matched sections
     '''
     ret = dict()
     for section in uci.get(config, list=True, default=[]):
@@ -177,11 +178,11 @@ def get_all_devices_by_zone(uci, zone):
     Retrieve all devices associated to the given zone
 
     Arguments:
-      uci -- EUci pointer
-      zone -- Firewall zone name
+      - uci -- EUci pointer
+      - zone -- Firewall zone name
 
     Returns:
-      A list of device names
+      - A list of device names
     '''
     devices = []
     for section in uci.get("firewall"):
@@ -205,10 +206,10 @@ def get_all_wan_devices(uci):
     Retrieve all devices associated to the wan zone
 
     Arguments:
-      uci -- EUci pointer
+      - uci -- EUci pointer
 
     Returns:
-      A list of device names
+      - A list of device names
     '''
     return get_all_devices_by_zone(uci, 'wan')
 
@@ -217,10 +218,10 @@ def get_all_lan_devices(uci):
     Retrieve all devices associated to the lan zone
 
     Arguments:
-      uci -- EUci pointer
+      - uci -- EUci pointer
 
     Returns:
-      A list of device names
+      - A list of device names
     '''
     return get_all_devices_by_zone(uci, 'lan')
 
@@ -229,13 +230,12 @@ def get_user_addresses(uci, user):
     Retrieve all IP addresses associated to given user
 
     Arguments:
-      uci -- EUci pointer
-      user -- User object id (UCI section)
+      - uci -- EUci pointer
+      - user -- User object id (UCI section)
 
-    Returns:
-      A tuple of lists:
-        - first element is a list of IPv4 addresses
-        - second element is a list of IPv6 addresses
+    Returns a tuple of lists:
+      - first element is a list of IPv4 addresses
+      - second element is a list of IPv6 addresses
     '''
     ipv4 = []
     ipv6 = []
@@ -272,11 +272,11 @@ def get_user_macs(uci, user):
     Retrieve all MAC addresses associated to given user
 
     Arguments:
-      uci -- EUci pointer
-      user -- User object id (UCI section)
+      - uci -- EUci pointer
+      - user -- User object id (UCI section)
 
     Returns:
-      A list of MAC addresses
+      - A list of MAC addresses
     '''
     return list(uci.get('objects', user, 'macaddr', list=True, default=[]))
 
@@ -285,11 +285,11 @@ def get_group_addresses(uci, group):
     Retrieve all IP addresses associated to given group
 
     Arguments:
-      uci -- EUci pointer
-      user -- Group object id (UCI section)
+      - uci -- EUci pointer
+      - user -- Group object id (UCI section)
 
     Returns:
-      A tuple of lists:
+      - A tuple of lists:
         - first element is a list of IPv4 addresses
         - second element is a list of IPv6 addresses
     '''
@@ -306,11 +306,11 @@ def get_group_macs(uci, group):
     Retrieve all MAC addresses associated to given user
 
     Arguments:
-      uci -- EUci pointer
-      group -- Group object id (UCI section)
+      - uci -- EUci pointer
+      - group -- Group object id (UCI section)
 
     Returns:
-      A list of MAC addresses
+      - A list of MAC addresses
     '''
     macs = []
     for u in uci.get('objects', group, 'user', list=True, default=[]):

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -11,6 +11,21 @@ config zone lan1
 	option forward 'ACCEPT'
 	list device 'eth0'
 
+config zone grey
+	option name 'grey'
+	list network 'grey1'
+	option input 'DROP'
+	option output 'ACCEPT'
+	option forward 'DROP'
+	list device 'eth1'
+
+config zone orange
+	option name 'orange'
+	list network 'orange1'
+	option input 'DROP'
+	option output 'DROP'
+	option forward 'DROP'
+
 config zone wan1
 	option name 'wan'
 	list network 'wan'
@@ -29,6 +44,52 @@ config forwarding fw1
 network_db = """
 config interface lan
 	option device 'vnet3'
+
+config interface lan2
+	option device 'vnet4'
+
+config interface grey1
+	option device 'vnet5'
+
+config interface orange1
+	option device 'vnet6'
+"""
+
+ns_api_db = """
+# Service groups
+config default_service_group 'ns_web_secure'
+	option name 'Secure web navigation'
+	list services '80/tcp/HTTP'
+	list services '443/tcp/HTTP Secure'
+	list services '53/udp/DNS'
+
+# Blue zone
+config default_zone 'ns_blue'
+	option name 'blue'
+	option forward 'DROP'
+	option input 'DROP'
+	option output 'ACCEPT'
+	option ns_description 'Guest network with Internet access'
+    list forwardings 'ns_blue2wan'
+    list forwardings 'ns_blue2lan'
+	# requires network option
+
+config default_forwarding 'ns_blue2wan'
+	option src 'blue'
+	option dest 'wan'
+
+config default_forwarding 'ns_blue2lan'
+	option src 'blue'
+	option dest 'lan'
+
+# Default rule
+config default_rule 'ns_allow_ui'
+	option name 'Allow-ui'
+	option src 'wan'
+	option dest_port '__PORT__'
+	option proto '__PROTO__'
+	option target 'ACCEPT'
+	option enabled '1'
 """
 
 def _setup_db(tmp_path):
@@ -37,6 +98,8 @@ def _setup_db(tmp_path):
         fp.write(firewall_db)
     with tmp_path.joinpath('network').open('w') as fp:
         fp.write(network_db)
+    with tmp_path.joinpath('ns-api').open('w') as fp:
+        fp.write(ns_api_db)
     return EUci(confdir=tmp_path.as_posix())
 
 def test_add_to_zone(tmp_path):
@@ -121,3 +184,61 @@ def test_add_trusted_zone_with_networks(tmp_path):
 def test_apply():
     # Already tested in pyuci
     assert 1
+
+def test_add_default_rule(tmp_path):
+    u = _setup_db(tmp_path)
+    rule = firewall.add_default_rule(u, 'ns_allow_ui', 'tcp', '443')
+    print(rule)
+    assert u.get("firewall", rule) == "rule"
+    assert u.get("firewall", rule, "proto") == "tcp"
+    assert u.get("firewall", rule, "name") == "Allow-ui"
+    assert u.get("firewall", rule, "src") == "wan"
+    assert u.get("firewall", rule, "dest_port") == "443"
+    assert u.get("firewall", rule, "enabled") == "1"
+    assert u.get("firewall", rule, "target") == "ACCEPT"
+    assert u.get("firewall", rule, "ns_tag") == "automated"
+
+def test_add_default_zone(tmp_path):
+    u = _setup_db(tmp_path)
+    (zone, forwardings) = firewall.add_default_zone(u, 'ns_blue', ["lan", "lan2"] )
+    assert zone is not None
+    assert u.get("firewall", zone) == "zone"
+    assert u.get("firewall", zone, "name") == "blue"
+    assert u.get("firewall", zone, "forward") == "DROP"
+    assert u.get("firewall", zone, "input") == "DROP"
+    assert u.get("firewall", zone, "output") == "ACCEPT"
+    assert u.get("firewall", zone, "ns_description") == "Guest network with Internet access"
+    assert u.get("firewall", zone, "ns_tag") ==  "automated"
+    assert "lan" in u.get("firewall", zone, "network", list=True)
+    assert "lan2" in u.get("firewall", zone, "network", list=True)
+    assert len(forwardings) == 2
+    for f in forwardings:
+        assert u.get("firewall", f) == "forwarding"
+        assert u.get("firewall", f, "ns_tag") == "automated"
+        assert u.get("firewall", f, "src") == "blue" or u.get("firewall", f, "dest") == "blue"
+    (zone, forwardings) = firewall.add_default_zone(u, 'ns_blue')
+    assert zone is None
+    assert forwardings is None
+
+def test_allow_default_service_group(tmp_path):
+    u = _setup_db(tmp_path)
+    sections = firewall.add_default_service_group(u, "ns_web_secure")
+    assert len(sections) == 2
+    assert u.get("firewall", sections[0]) == "rule"
+    assert u.get("firewall", sections[0], "src") == "lan"
+    assert u.get("firewall", sections[0], "dest") == "wan"
+    assert u.get("firewall", sections[0], "proto") == "tcp"
+    assert u.get("firewall", sections[0], "dest_port") == "80,443"
+    assert u.get("firewall", sections[0], "ns_tag") ==  "automated"
+
+    assert u.get("firewall", sections[1]) == "rule"
+    assert u.get("firewall", sections[1], "src") == "lan"
+    assert u.get("firewall", sections[1], "dest") == "wan"
+    assert u.get("firewall", sections[1], "proto") == "udp"
+    assert u.get("firewall", sections[1], "dest_port") == "53"
+    
+    sections = firewall.add_default_service_group(u, "ns_web_secure", "grey", "orange")
+    assert u.get("firewall", sections[0], "src") == "grey"
+    assert u.get("firewall", sections[0], "dest") == "orange"
+    assert u.get("firewall", sections[0], "proto") == "tcp"
+    assert u.get("firewall", sections[1], "proto") == "udp"

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -124,10 +124,11 @@ def test_add_service(tmp_path):
     u = _setup_db(tmp_path)
     rule = firewall.add_service(u, "my_service", "443", "tcp", "nginx/_lan")
     assert rule is not None
-    assert u.get('firewall', 'ns_allow_my_service', 'dest_port') == '443'
-    assert u.get('firewall', 'ns_allow_my_service', 'proto') == 'tcp'
-    assert u.get('firewall', 'ns_allow_my_service', 'src') == 'wan'
-    assert u.get('firewall', 'ns_allow_my_service', 'name') == 'Allow-my_service'
+    assert rule == "ns_allow_my_service"
+    assert u.get('firewall', rule, 'dest_port') == '443'
+    assert u.get('firewall', rule, 'proto') == 'tcp'
+    assert u.get('firewall', rule, 'src') == 'wan'
+    assert u.get('firewall', rule, 'name') == 'Allow-my_service'
     assert u.get('firewall', rule, 'ns_link') == "nginx/_lan"
     assert u.get('firewall', rule, 'ns_tag') == "automated"
 
@@ -210,8 +211,7 @@ def test_apply():
 
 def test_add_default_rule(tmp_path):
     u = _setup_db(tmp_path)
-    rule = firewall.add_default_rule(u, 'ns_test_rule', 'tcp', '443')
-    print(rule)
+    rule = firewall.add_default_rule(u, 'ns_test_rule', 'tcp', '443', 'test1/key1')
     assert u.get("firewall", rule) == "rule"
     assert u.get("firewall", rule, "proto") == "tcp"
     assert u.get("firewall", rule, "name") == "Test-rule"
@@ -221,6 +221,7 @@ def test_add_default_rule(tmp_path):
     assert u.get("firewall", rule, "enabled") == "1"
     assert u.get("firewall", rule, "target") == "ACCEPT"
     assert u.get("firewall", rule, "ns_tag") == "automated"
+    assert u.get("firewall", rule, "ns_link") == "test1/key1"
 
 def test_add_default_zone(tmp_path):
     u = _setup_db(tmp_path)
@@ -260,9 +261,69 @@ def test_allow_default_service_group(tmp_path):
     assert u.get("firewall", sections[1], "dest") == "wan"
     assert u.get("firewall", sections[1], "proto") == "udp"
     assert u.get("firewall", sections[1], "dest_port") == "53"
+    assert u.get("firewall", sections[1], "ns_tag") ==  "automated"
     
     sections = firewall.add_default_service_group(u, "ns_web_secure", "grey", "orange")
     assert u.get("firewall", sections[0], "src") == "grey"
     assert u.get("firewall", sections[0], "dest") == "orange"
     assert u.get("firewall", sections[0], "proto") == "tcp"
     assert u.get("firewall", sections[1], "proto") == "udp"
+    
+    sections = firewall.add_default_service_group(u, "ns_web_secure", "blue", "yellow", link="db/mykey")
+    assert u.get("firewall", sections[0], "ns_link") == "db/mykey"
+    assert u.get("firewall", sections[1], "ns_link") == "db/mykey"
+
+def test_get_all_linked(tmp_path):
+    u = _setup_db(tmp_path)
+    link = "mytestdb/mykey"
+    sections = firewall.add_default_service_group(u, "ns_web_secure", "blue", "yellow", link=link)
+    rule = firewall.add_service(u, "my_service", "443", "tcp", link=link)
+    interface = firewall.add_vpn_interface(u, 'p2p', 'ppp10', link=link)
+    (zone, forwardings) = firewall.add_trusted_zone(u, 'mylinked', link=link)
+    linked = firewall.get_all_linked(u, link)
+    for s in sections:
+        assert s in linked['firewall']
+    assert rule in linked['firewall']
+    assert zone in linked['firewall']
+    for f in forwardings:
+        assert f in linked['firewall']
+    assert interface in linked['network']
+
+
+def test_disable_linked_rules(tmp_path):
+    u = _setup_db(tmp_path)
+    link = "mytestdb/mykey"
+    sections = firewall.add_default_service_group(u, "ns_web_secure", "blue", "yellow", link=link)
+    rule = firewall.add_service(u, "my_service", "443", "tcp", link=link)
+    interface = firewall.add_vpn_interface(u, 'p2p', 'ppp10', link=link)
+    (zone, forwardings) = firewall.add_trusted_zone(u, 'mylinked', link=link)
+    disabled = firewall.disable_linked_rules(u, link)
+    for s in sections:
+        assert u.get("firewall", s, "enabled") == "0"
+        assert s in disabled
+    assert u.get("firewall", rule, "enabled") == "0"
+    assert rule in disabled
+    assert u.get("firewall", zone, "enabled", default="XX") == "XX" # option must not be set
+    assert u.get("network", interface, "enabled", default="XX") == "XX" # option must not be set
+    for f in forwardings:
+        assert u.get("network", f, "enabled", default="XX") == "XX" # option must not be set
+
+def test_delete_linked_sections(tmp_path):
+    u = _setup_db(tmp_path)
+    link = "mytestdb/mykey"
+    sections = firewall.add_default_service_group(u, "ns_web_secure", "blue", "yellow", link=link)
+    rule = firewall.add_service(u, "my_service", "443", "tcp", link=link)
+    interface = firewall.add_vpn_interface(u, 'p2p', 'ppp10', link=link)
+    (zone, forwardings) = firewall.add_trusted_zone(u, 'mylinked', link=link)
+    deleted = firewall.delete_linked_sections(u, link)
+    assert len(deleted) > 0
+    with pytest.raises(UciExceptionNotFound):
+        u.get("firewall", rule)
+    with pytest.raises(UciExceptionNotFound):
+        u.get("firewall", zone)
+    with pytest.raises(UciExceptionNotFound):
+        for s in sections:
+            u.get("firewall", s)
+    with pytest.raises(UciExceptionNotFound):
+        for f in forwardings:
+            u.get("firewall", f)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -181,6 +181,7 @@ def test_get_all_by_option(tmp_path):
     u = _setup_db(tmp_path)
     return_map = {"section1": u.get_all("test", "section1"), "section2": u.get_all("test", "section2")}
     assert(utils.get_all_by_option(u, 'test', 'opt2', 'value2') == return_map)
+    assert(utils.get_all_by_option(u, 'test', 'opt2', 'value2', deep = False) == list(return_map.keys()))
 
 def test_get_all_wan_devices(tmp_path):
     u = _setup_db(tmp_path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -213,3 +213,10 @@ def test_get_group_addresses(tmp_path):
 def test_get_group_macs(tmp_path):
     u = _setup_db(tmp_path)
     assert(utils.get_group_macs(u, 'vip') == ["52:54:00:9d:3d:e5"])
+
+def test_get_random_id():
+    id1 = utils.get_random_id()
+    id2 = utils.get_random_id()
+    assert len(id1) == 11
+    assert id1[0:3] == "ns_"
+    assert id1 != id2


### PR DESCRIPTION
This PR is required for the implementation of the following features:
- installation templates: create a configuration template for a firewall which can easily be reproducible in similar scenarios
- automatic configuration of known services, currently known services are:
  - OpenVPN RoadWarrior, action: change listening port or add a new instance
  - OpenVPN tunnel, action: change listening port or add a new instance
  - Wireguard, action: change listening port or add a new instance
  - Dedalo hotspot: enable/disable the service
  - Nginx: change management UI port
- configuration wizards like:
  - first configuration with 3 zones lan, wan and guests: automatically create the blue zone for guests
  - first configuration with strict mode where all traffic is closed from lan to wan: enable the access of a list of wll known services

# New prefixed options

NethSecurity adds some options to existing UCI records.
Newly added options have the `ns_` prefix to avoid naming collision with UCI.

New options:
- option `ns_description`: it's a text description of the record
- list `ns_tag`: a list of tags, all code-generated sections have the `automated` tag
- option `ns_link`: a reference to another object in the format `<config>/<section>`, example: `firewall/rule1`

New functions:
- `get_all_linked`: this could be used by the UI to see the relations between sections
- `disable_linked_rules`: this could be used to disable all rules linked to a given service, like an OpenVPN roadwarrior server
- `delete_linked_sections`: this could be used to delete all rules, zones and any other section linked to a given service, like an OpenVPN tunnel

# Template database

The `templates` database contains some special sections which can be used as template to generate new sections inside the real UCI configuration files. This is a list of currently supported files.

## Service groups
        
Record type: `template_service_group`

Description: this section defines service groups, which are collections of multiple network services. Each service group has a name and includes various services with their corresponding ports and protocols. It generated a rule for each protocol (`udp` or `tcp`) where all services a grouped

Options:
- option `name`: specifies the name or description of the service group, it can be used inside the UI
- list `services`: represents a list of network services included in the service group. 
      Each service is defined with a string in the form `<port>/<protocol>/<name>' like `80/tcp/HTTP`

Example:
```
config template_service_group 'ns_web_secure'
	option name 'Secure web navigation'
	list services '80/tcp/HTTP'
	list services '443/tcp/HTTP Secure'
	list services '53/udp/DNS'
```

## Zones

Record type: `template_zone`

Description: this section defines network zones, each with a distinct purpose and network policies. Zones specify how traffic is handled, such as allowing or dropping incoming and outgoing packets.

Contains all options from UCI `zone`, plus the following:
- list `forwardings`: a list of forwardings to create for this zone, see below
- option `ns_description`

Example:
```
config template_zone 'ns_blue'
	option name 'blue'
	option forward 'DROP'
	option input 'DROP'
	option output 'ACCEPT'
	option ns_description 'Guest network with Internet access'
	list forwardings 'ns_blue2wan'

config template_forwarding 'ns_blue2wan'
	option src 'blue'
	option dest 'wan'
```

##  Forwarding rules

Record types: `template_forwarding`

Description: this section defines forwarding rules that determine how traffic is forwarded between different zones. Each forwarding rule specifies a source zone and a destination zone.

See zones for an example.

## Rules

Record type: `template_rule`

Description: this section defines a template rule that applies to specific traffic between zones. The rule sets conditions for packet acceptance or rejection based on the source and destination zones, ports, and protocols. The placeholders `__PORT__` and `__PROTO__` are intended to be replaced with actual port numbers and protocols.

Example:
```
config template_rule 'ns_test_rule'
	option name 'Test-rule'
	option src 'wan'
	option dest 'blue'
	option dest_port '__PORT__'
	option proto '__PROTO__'
	option target 'ACCEPT'
	option enabled '1'
```

## New functions

Added the following functions to create sections from a template database named `ns-api`:

- `add_template_zone`: create a new zone from a 
- `add_template_forwarding`: it used by the `add_template_zone` to create all required forwardings
- `add_template_service_group`
- `add_template_rule`
