### PR TITLE
fix: fixed wrong app name scheme in rules

### DIFF
--- a/src/nethsec/dpi/__init__.py
+++ b/src/nethsec/dpi/__init__.py
@@ -231,7 +231,7 @@ def __save_rule_data(e_uci: EUci, config_name: str, enabled: bool, interface: st
     e_uci.set('dpi', config_name, 'enabled', enabled)
     e_uci.set('dpi', config_name, 'interface', interface)
     e_uci.set('dpi', config_name, 'action', action)
-    e_uci.set('dpi', config_name, 'application', [f'netify.{application}' for application in applications])
+    e_uci.set('dpi', config_name, 'application', applications)
     e_uci.set('dpi', config_name, 'protocol', protocols)
 
 

--- a/tests/test_dpi.py
+++ b/tests/test_dpi.py
@@ -618,8 +618,8 @@ def test_list_rules(e_uci_with_dpi_data, mock_load):
 
 
 def test_store_rule(e_uci, mock_load):
-    rule_created = dpi.add_rule(e_uci, True, 'lan', 'best_effort', ['linkedin', 'avira', 'netflix'],
-                                ['LotusNotes', 'SFlow'])
+    rule_created = dpi.add_rule(e_uci, True, 'lan', 'best_effort',
+                                ['netify.linkedin', 'netify.avira', 'netify.netflix'], ['LotusNotes', 'SFlow'])
     assert dpi.list_rules(e_uci) == [
         {
             'config-name': rule_created,


### PR DESCRIPTION
Due to latest changes, a prefix append to applications was missed during the PR review.

This fixes the issue.