### PR TITLE
dpi: disable and enable global flag

### DIFF
--- a/src/nethsec/dpi/__init__.py
+++ b/src/nethsec/dpi/__init__.py
@@ -335,6 +335,17 @@ def __save_rule_data(e_uci: EUci, config_name: str, enabled: bool, device: str, 
     e_uci.set('dpi', config_name, 'application', applications)
     e_uci.set('dpi', config_name, 'protocol', protocols)
 
+def __toggle_engine(e_uci: EUci):
+    count_enabled = 0
+    for section in e_uci.get_all('dpi'):
+        if e_uci.get('dpi', section, default="") == "rule" and e_uci.get('dpi', section, 'enabled', default="0") == "1":
+            count_enabled = count_enabled + 1
+
+    if count_enabled > 0:
+        print(e_uci.get_all('dpi'))
+        e_uci.set('dpi', 'config', 'enabled', '1')
+    else:
+        e_uci.set('dpi', 'config', 'enabled', '0')
 
 def add_rule(e_uci: EUci, enabled: bool, device: str, action: str, applications: list[str],
              protocols: list[str]) -> str:
@@ -356,6 +367,7 @@ def add_rule(e_uci: EUci, enabled: bool, device: str, action: str, applications:
     rule_name = utils.get_random_id()
     e_uci.set('dpi', rule_name, 'rule')
     __save_rule_data(e_uci, rule_name, enabled, device, action, applications, protocols)
+    __toggle_engine(e_uci)
     e_uci.save('dpi')
     return rule_name
 
@@ -369,6 +381,7 @@ def delete_rule(e_uci: EUci, config_name: str):
       - config_name: config name of the rule to delete
     """
     e_uci.delete('dpi', config_name)
+    __toggle_engine(e_uci)
     e_uci.save('dpi')
 
 
@@ -393,5 +406,6 @@ def edit_rule(e_uci: EUci, config_name: str, enabled: bool, device: str, action:
         raise ValidationError('config-name', 'invalid', config_name)
 
     __save_rule_data(e_uci, config_name, enabled, device, action, applications, protocols)
+    __toggle_engine(e_uci)
 
     e_uci.save('dpi')

--- a/tests/test_dpi.py
+++ b/tests/test_dpi.py
@@ -207,6 +207,13 @@ protocol_output = """
    130: HTTP/Connect
 """
 
+dpi_minimal_db = """
+config main 'config'
+    option log_blocked '0'
+    option firewall_exemption '0'
+    option enabled '0'
+"""
+
 dpi_db = """
 config main 'config'
     option log_blocked '0'
@@ -326,7 +333,7 @@ def e_uci(tmp_path: pathlib.Path) -> EUci:
     save_dir = tmp_path.joinpath('save')
     save_dir.mkdir()
     with conf_dir.joinpath('dpi').open('w') as fp:
-        fp.write("")
+        fp.write(dpi_minimal_db)
     with conf_dir.joinpath('network').open('w') as fp:
         fp.write(network_config)
     with conf_dir.joinpath('firewall').open('w') as fp:
@@ -770,6 +777,7 @@ def test_store_rule(e_uci, mock_load):
             ]
         }
     ]
+    assert(e_uci.get("dpi", "config", "enabled") == "1")
 
 
 def test_delete_rule(e_uci_with_data, mock_load):
@@ -794,6 +802,9 @@ def test_delete_rule(e_uci_with_data, mock_load):
             ]
         }
     ]
+    dpi.delete_rule(e_uci_with_data, 'rule2')
+    dpi.delete_rule(e_uci_with_data, 'rule3')
+    assert(e_uci_with_data.get("dpi", "config", "enabled") == "0")
 
 
 def test_edit_rule(e_uci_with_data, mock_load):


### PR DESCRIPTION
Enable global flag if there is at least one enabled rule. Disable the global flag, otherwise

Card: https://trello.com/c/LtBmGma7/203-dpi-filter-always-disabled