### PR TITLE
Firewall lib: default IPv6 rules

### DIFF
--- a/src/nethsec/firewall/__init__.py
+++ b/src/nethsec/firewall/__init__.py
@@ -690,14 +690,15 @@ def get_zone_by_name(uci, name: str) -> str:
             return (z, zones[z])
     return (None, None)
 
-def get_rule_by_name(uci, name: str) -> str:
+def get_rule_by_name(uci, name: str, tag = "") -> str:
     """
-    Get rule config name by rule name.
+    Get rule config name and rule data by rule name, optionally filtered by tag.
     Assume there is only one rule with the same name.
 
     Args:
         uci: EUci pointer
         name: rule name
+        tag: optional tag to filter rules
 
     Returns:
         tuple of rule config name and rule config if rule with name name exists, (None, None) otherwise
@@ -705,7 +706,8 @@ def get_rule_by_name(uci, name: str) -> str:
     rules = utils.get_all_by_type(uci, 'firewall', 'rule')
     for r in rules:
         if uci.get('firewall', r, 'name', default='') == name:
-            return (r, rules[r])
+            if not tag or tag in uci.get('firewall', r, 'ns_tag', default=[]):
+                return (r, rules[r])
     return (None, None)
 
 
@@ -878,6 +880,7 @@ def add_default_ipv6_rules(uci):
     ret = list()
     rules = {"ip6_dhcp" : "Allow-DHCPv6", "ip6_mld" : "Allow-MLD", "ip6_icmp" : "Allow-ICMPv6-Input", "ip6_icmp_forward" : "Allow-ICMPv6-Forward"}
     for r in rules:
-        if not get_rule_by_name(uci, rules[r])[0]:
+        (rule_name, rule) = get_rule_by_name(uci, rules[r], tag="automated")
+        if rule_name is None:
             ret.append(add_template_rule(uci, r))
     return ret

--- a/src/nethsec/firewall/__init__.py
+++ b/src/nethsec/firewall/__init__.py
@@ -690,6 +690,25 @@ def get_zone_by_name(uci, name: str) -> str:
             return (z, zones[z])
     return (None, None)
 
+def get_rule_by_name(uci, name: str) -> str:
+    """
+    Get rule config name by rule name.
+    Assume there is only one rule with the same name.
+
+    Args:
+        uci: EUci pointer
+        name: rule name
+
+    Returns:
+        tuple of rule config name and rule config if rule with name name exists, (None, None) otherwise
+    """
+    rules = utils.get_all_by_type(uci, 'firewall', 'rule')
+    for r in rules:
+        if uci.get('firewall', r, 'name', default='') == name:
+            return (r, rules[r])
+    return (None, None)
+
+
 def zone_exists(u, zone_name):
     """
     Check if a zone with name zone_name already exists

--- a/src/nethsec/firewall/__init__.py
+++ b/src/nethsec/firewall/__init__.py
@@ -864,3 +864,20 @@ def delete_zone(uci, zone_config_name: str) -> {str, set[str]}:
     uci.delete('firewall', zone_config_name)
     uci.save('firewall')
     return zone_config_name, to_delete_forwardings
+
+def add_default_ipv6_rules(uci):
+    """
+    Add default ipv6 rules to firewall config, if they don't exist already.
+
+    Args:
+        uci: EUci pointer
+    
+    Returns:
+        list of added rule config names
+    """
+    ret = list()
+    rules = {"ip6_dhcp" : "Allow-DHCPv6", "ip6_mld" : "Allow-MLD", "ip6_icmp" : "Allow-ICMPv6-Input", "ip6_icmp_forward" : "Allow-ICMPv6-Forward"}
+    for r in rules:
+        if not get_rule_by_name(uci, rules[r])[0]:
+            ret.append(add_template_rule(uci, r))
+    return ret

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -48,6 +48,14 @@ config rule 'v6rule'
     option dest_port '546'
     option family 'ipv6'
     option target 'ACCEPT'
+
+config rule 'manrule'
+    option name 'Not-Automated'
+    option src 'wan'
+    option proto 'tcp'
+    option dest_port '1234'
+    option family 'ipv4'
+    option target 'ACCEPT'
 """
 
 network_db = """
@@ -595,7 +603,12 @@ def test_get_rule_by_name(tmp_path):
         "v6rule",
         {"name": "Allow-DHCPv6", "src": "wan", "proto": "udp", "dest_port": "546", "family": "ipv6", "target": "ACCEPT", "enabled": "0"}
     )
+    assert firewall.get_rule_by_name(u, "Not-Automated") == (
+        "manrule",
+        {"name": "Not-Automated", "src": "wan", "proto": "tcp", "dest_port": "1234", "family": "ipv4", "target": "ACCEPT"}
+    )
     assert firewall.get_rule_by_name(u, "not_a_rule") == (None, None)
+    assert firewall.get_rule_by_name(u, "Not-Automated", "automated") == (None, None)
 
 def test_add_default_ipv6_rules(tmp_path):
     u = _setup_db(tmp_path)

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -538,3 +538,11 @@ def test_delete_zone(tmp_path):
         "ns_new_zone", {"ns_new_zone2lan", "ns_guest2new_zone", "ns_lan2new_zone"})
     with pytest.raises(Exception) as e:
         firewall.delete_zone(u, "not_a_zone")
+
+def test_get_rule_by_name(tmp_path):
+    u = _setup_db(tmp_path)
+    assert firewall.get_rule_by_name(u, "Allow-DHCPv6") == (
+        "v6rule",
+        {"name": "Allow-DHCPv6", "src": "wan", "proto": "udp", "dest_port": "546", "family": "ipv6", "target": "ACCEPT", "enabled": "0"}
+    )
+    assert firewall.get_rule_by_name(u, "not_a_rule") == (None, None)


### PR DESCRIPTION
Create a new `add_default_ipv6_rules` method which can be used by the ns.devices APIs.
The new method adds required ipv6 rules only if not they already exists.
