### PR TITLE
dpi: list devices configured inside netifyd

### DIFF
--- a/src/nethsec/dpi/__init__.py
+++ b/src/nethsec/dpi/__init__.py
@@ -169,7 +169,8 @@ def list_devices(e_uci: EUci):
     config = e_uci.get_all("netifyd")
     cname = list(config.keys())[0]
 
-    for device in config[cname].get('internal_if') + config[cname].get('external_if'):
+    # exclude wan devices
+    for device in config[cname].get('internal_if') :
         interface = utils.get_interface_from_device(e_uci, device)
         ret.append({
             'interface': interface if interface is not None else device,

--- a/src/nethsec/dpi/__init__.py
+++ b/src/nethsec/dpi/__init__.py
@@ -165,28 +165,18 @@ def list_devices(e_uci: EUci):
     Returns:
         list of dicts, each dict contains the property "interface" and "device"
     """
-    zones = firewall.list_zones(e_uci)
+    ret = []
+    config = e_uci.get_all("netifyd")
+    cname = list(config.keys())[0]
 
-    # filter out wan zone
-    zones = [zone['name'] for zone in zones.values() if zone['name'] != 'wan']
-
-    # get all devices from zones
-    devices = set()
-    for zone in zones:
-        for device in utils.get_all_devices_by_zone(e_uci, zone):
-            devices.add(device)
-
-    filtered_devices = []
-    # get all interfaces from network
-    for device in devices:
+    for device in config[cname].get('internal_if') + config[cname].get('external_if'):
         interface = utils.get_interface_from_device(e_uci, device)
-        if interface is not None:
-            filtered_devices.append({
-                'interface': interface,
-                'device': device
-            })
+        ret.append({
+            'interface': interface if interface is not None else device,
+            'device': device
+        })
 
-    return filtered_devices
+    return ret
 
 
 def list_applications(search: str = None, limit: int = None, page: int = 1) -> dict:

--- a/tests/test_dpi.py
+++ b/tests/test_dpi.py
@@ -339,7 +339,6 @@ config zone 'ns_guests'
         option input 'REJECT'
         option output 'ACCEPT'
         option forward 'REJECT'
-        list network 'RED_1'
         list network 'GREEN_1'
         
 config zone 'ns_empty'
@@ -914,10 +913,11 @@ def test_list_interfaces(e_uci_with_data):
         'interface': 'GREEN_2',
         'device': 'eth4'
     }) != -1
-    assert dpi.list_devices(e_uci_with_data).index({
-        'interface': 'RED_1',
-        'device': 'eth1'
-    }) != -1
+    with pytest.raises(ValueError):
+        assert dpi.list_devices(e_uci_with_data).index({
+            'interface': 'RED_1',
+            'device': 'eth1'
+        })
 
 
 def test_list_popular(e_uci_with_data, mock_load):

--- a/tests/test_dpi.py
+++ b/tests/test_dpi.py
@@ -264,6 +264,18 @@ config exemption exemp1
     option enabled 1
 """
 
+netifyd_config = """
+config netifyd
+	option enabled '1'
+	option autoconfig '0'
+	list internal_if 'br-lan'
+	list internal_if 'eth0'
+	list internal_if 'eth4'
+	list internal_if 'tunrw1'
+	list external_if 'eth2'
+	list external_if 'eth1'
+"""
+
 network_config = """
 config interface 'RED_1'
         option proto 'dhcp'
@@ -293,6 +305,13 @@ config interface 'GREEN_2'
         option ipaddr '10.0.3.1'
         option netmask '255.255.255.0'
         option gateway '10.0.3.0'
+
+config interface 'GREEN_3'
+        option proto 'static'
+        option device 'br_lan'
+        option ipaddr '10.1.1.1'
+        option netmask '255.255.255.0'
+        option gateway '10.1.1.0'
 """
 
 firewall_config = """
@@ -350,6 +369,8 @@ def e_uci(tmp_path: pathlib.Path) -> EUci:
 def e_uci_with_data(e_uci: EUci):
     with pathlib.Path(e_uci.confdir()).joinpath('dpi').open('w') as fp:
         fp.write(dpi_db)
+    with pathlib.Path(e_uci.confdir()).joinpath('netifyd').open('w') as fp:
+        fp.write(netifyd_config)
     return e_uci
 
 


### PR DESCRIPTION
The netifyd configuration is now updated at every network configuration change.
Use netifyd internal_if and external_if options to retrieve the list of available interfaces.

Card: https://trello.com/c/ShnFDa4G/135-netifyd-listening-changes