### PR TITLE
ipsec: remove interface option

### DIFF
--- a/src/nethsec/ipsec/__init__.py
+++ b/src/nethsec/ipsec/__init__.py
@@ -34,7 +34,6 @@ def init_ipsec(uci):
         uci.set("ipsec", gsettings, IPSEC_ZONE)
         uci.set("ipsec", gsettings, "debug", '0')
         uci.set("ipsec", gsettings, "zone", 'ipsec')
-        uci.set("ipsec", gsettings, "interface", ['wan'])
         uci.commit('ipsec')
 
 def open_firewall_ports(uci):

--- a/tests/test_ipsec.py
+++ b/tests/test_ipsec.py
@@ -49,7 +49,6 @@ def test_init_ipsec(e_uci):
     assert(e_uci.get('ipsec', 'ns_ipsec_global') == 'ipsec')
     assert(e_uci.get('ipsec', 'ns_ipsec_global', 'debug') == '0')
     assert(e_uci.get('ipsec', 'ns_ipsec_global', 'zone') == ipsec.IPSEC_ZONE)
-    assert(e_uci.get_all('ipsec', 'ns_ipsec_global', 'interface') == ('wan',))
 
 def test_open_firewall_ports(e_uci_with_data):
     ipsec.open_firewall_ports(e_uci_with_data)


### PR DESCRIPTION
If the interface option is set to a non-exiting interface, IPsec tunnels are not created.
This is a common scenario after the migration.

Please note that this change will take effect on non-migrated machines.