### PR TITLE
utils: fix list of pppoe IPs

### DIFF
--- a/src/nethsec/utils/__init__.py
+++ b/src/nethsec/utils/__init__.py
@@ -502,8 +502,12 @@ def get_all_wan_ips(uci):
                     continue
                 if ip not in seen:
                     seen.add(ip)
-                    interface = get_interface_from_device(uci, device)
-                    ret.append({"device": f'{interface.replace("@","")} ({device})', "ipaddr": ip})
+                    if device.startswith('pppoe-'):
+                        interface = device.removeprefix('pppoe-')
+                    else:
+                        interface = get_interface_from_device(uci, device)
+                    if interface:
+                        ret.append({"device": f'{interface.replace("@","")} ({device})', "ipaddr": ip})
 
     return sorted(ret, key=lambda k: k['ipaddr'])
 


### PR DESCRIPTION
Avoid the following error when listing IPs
of pppoe-xxxx devices.
```
  File "/usr/lib/python3.11/site-packages/nethsec/utils/__init__.py", line 506, in get_all_wan_ips
    ret.append({"device": f'{interface.replace("@","")} ({device})', "ipaddr": ip})
                             ^^^^^^^^^^^^^^^^^
  AttributeError: 'NoneType' object has no attribute 'replace'
```
NethServer/nethsecurity#540