### PR TITLE
fix(inventory): small fixes and improvements

### DIFF
--- a/src/nethsec/inventory/__init__.py
+++ b/src/nethsec/inventory/__init__.py
@@ -45,10 +45,10 @@ def fact_openvpn_tun(uci: EUci):
     return ret
 
 def fact_subscription_status(uci: EUci):
-    return { 'status': uci.get('ns_plug', 'config', 'type', default='no') }
+    return { 'status': uci.get('ns-plug', 'config', 'type', default='no') }
 
 def fact_controller(uci: EUci):
-    if uci.get('ns_plug', 'config', 'server', default='') and uci.get('ns_plug', 'config', 'unit_id', default='') and uci.get('ns_plug', 'config', 'token', default=''):
+    if uci.get('ns-plug', 'config', 'server', default='') and uci.get('ns-plug', 'config', 'unit_id', default='') and uci.get('ns-plug', 'config', 'token', default=''):
         return { "enabled": True}
     else:
         return { "enabled": False}

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,8 +1,6 @@
-import pytest
-from nethsec import inventory
 from euci import EUci
-from unittest.mock import MagicMock, patch
 
+from nethsec import inventory
 
 firewall_db = """
 config zone wan1
@@ -529,7 +527,13 @@ def test_fact_storage(tmp_path):
      
 def test_fact_network(tmp_path):
 	u = _setup_db(tmp_path)
-	assert inventory.fact_network(u) == {"ipv6": 1, "ipv4": 6} # 2 more ipv4 interfaces from previous tests
+	result = inventory.fact_network(u)
+	assert result['blue']['ipv4'] == 1
+	assert result['blue']['ipv6'] == 0
+	assert result['lan']['ipv4'] == 1
+	assert result['lan']['ipv6'] == 0
+	assert result['wan']['ipv4'] == 1
+	assert result['wan']['ipv6'] == 0
       
 def test_fact_proxy_pass(tmp_path):
 	u = _setup_db(tmp_path)
@@ -549,7 +553,12 @@ def test_fact_dhcp_server(tmp_path):
       
 def test_fact_multiwan(tmp_path):
 	u = _setup_db(tmp_path)
-	assert inventory.fact_multiwan(u) == {"wans": 2, "type": "backup"}
+	result = inventory.fact_multiwan(u)
+	assert result['enabled']
+	assert result['policies']['backup'] == 1
+	assert result['policies']['balance'] == 0
+	assert result['policies']['custom'] == 0
+	assert result['rules'] == 1
       
 def test_fact_qos(tmp_path):
 	u = _setup_db(tmp_path)

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -469,7 +469,7 @@ def _setup_db(tmp_path):
         fp.write(flashstart_db)
     with tmp_path.joinpath('openvpn').open('w') as fp:
         fp.write(openvpn_db)
-    with tmp_path.joinpath('ns_plug').open('w') as fp:
+    with tmp_path.joinpath('ns-plug').open('w') as fp:
         fp.write(ns_plug_db)
     with tmp_path.joinpath('banip').open('w') as fp:
         fp.write(ban_ip_db)


### PR DESCRIPTION
Fixing following issues:
 - wrong database fetch in subscription environments
 - revamped data from network
 - revamped data from mwan

Query to retrieve stats of number of WANs in every firewall

```sql
WITH wan_interface_number AS (SELECT id,
                                     jsonb_path_query(to_jsonb(data), '$.facts.features.network.wan.*')::integer as interface_by_ipv_count
                              FROM installations
                              WHERE updated_at > NOW() - interval '7 day'),
     total_interfaces_per_id AS (SELECT id,
                                        SUM(interface_by_ipv_count) as total_interfaces
                                 FROM wan_interface_number
                                 GROUP BY id)
SELECT COUNT(id), total_interfaces
FROM total_interfaces_per_id
GROUP BY total_interfaces;
```