### PR TITLE
Fix name length validation in store_rule and store_policy functions

### DIFF
--- a/src/nethsec/mwan/__init__.py
+++ b/src/nethsec/mwan/__init__.py
@@ -143,10 +143,10 @@ def store_rule(e_uci: EUci, name: str, policy: str, protocol: str = None,
     Raises:
         ValidationError if name is not unique, policy is not valid or length get_id > 15
     """
-    # check if the rule length  is not more than 15 characters
+    # check if the rule length  is not more than 15 characters: 12 from user and 3 from get_id prefix
     if len(name) > 12:
         # get_id add 3 more chars (ns_) to the name
-        raise ValidationError('name', 'length_15_max', name)
+        raise ValidationError('name', 'length_12_max', name)
     rule_config_name = utils.get_id(name.lower(), 15)
     rules = utils.get_all_by_type(e_uci, 'mwan3', 'rule').keys()
     if e_uci.get('mwan3', rule_config_name, default=None) is not None:
@@ -191,7 +191,7 @@ def store_policy(e_uci: EUci, name: str, interfaces: list[dict]) -> list[str]:
     changed_config = []
     if len(name) > 12:
         # get_id add 3 more chars (ns_) to the name
-        raise ValidationError('name', 'length_15_max', name)
+        raise ValidationError('name', 'length_12_max', name)
     # generate policy name
     policy_config_name = utils.get_id(name.lower(), 15)
     #  test length of policy name

--- a/src/nethsec/mwan/__init__.py
+++ b/src/nethsec/mwan/__init__.py
@@ -141,8 +141,11 @@ def store_rule(e_uci: EUci, name: str, policy: str, protocol: str = None,
         name of the rule created
 
     Raises:
-        ValidationError if name is not unique or policy is not valid
+        ValidationError if name is not unique, policy is not valid or length name > 15
     """
+    # check if the rule length  is not more than 15 characters
+    if len(name) > 15:
+        raise ValidationError('name', 'length', name)
     rule_config_name = utils.get_id(name.lower(), 15)
     rules = utils.get_all_by_type(e_uci, 'mwan3', 'rule').keys()
     if e_uci.get('mwan3', rule_config_name, default=None) is not None:
@@ -182,11 +185,14 @@ def store_policy(e_uci: EUci, name: str, interfaces: list[dict]) -> list[str]:
         list of changed configuration
 
     Raises:
-        ValidationError: if name is not unique
+        ValidationError: if name is not unique or length name > 15
     """
     changed_config = []
     # generate policy name
     policy_config_name = utils.get_id(name.lower())
+    #  test length of policy name
+    if len(policy_config_name) > 15:
+        raise ValidationError('name', 'length', name)
     # make sure name is not something that already exists
     if e_uci.get('mwan3', policy_config_name, default=None) is not None:
         raise ValidationError('name', 'unique', name)

--- a/src/nethsec/mwan/__init__.py
+++ b/src/nethsec/mwan/__init__.py
@@ -145,7 +145,7 @@ def store_rule(e_uci: EUci, name: str, policy: str, protocol: str = None,
     """
     # check if the rule length  is not more than 15 characters
     if len(name) > 15:
-        raise ValidationError('name', 'length', name)
+        raise ValidationError('name', 'length_15_max', name)
     rule_config_name = utils.get_id(name.lower(), 15)
     rules = utils.get_all_by_type(e_uci, 'mwan3', 'rule').keys()
     if e_uci.get('mwan3', rule_config_name, default=None) is not None:
@@ -192,7 +192,7 @@ def store_policy(e_uci: EUci, name: str, interfaces: list[dict]) -> list[str]:
     policy_config_name = utils.get_id(name.lower())
     #  test length of policy name
     if len(policy_config_name) > 15:
-        raise ValidationError('name', 'length', name)
+        raise ValidationError('name', 'length_15_max', name)
     # make sure name is not something that already exists
     if e_uci.get('mwan3', policy_config_name, default=None) is not None:
         raise ValidationError('name', 'unique', name)

--- a/src/nethsec/mwan/__init__.py
+++ b/src/nethsec/mwan/__init__.py
@@ -193,7 +193,7 @@ def store_policy(e_uci: EUci, name: str, interfaces: list[dict]) -> list[str]:
         # get_id add 3 more chars (ns_) to the name
         raise ValidationError('name', 'length_15_max', name)
     # generate policy name
-    policy_config_name = utils.get_id(name.lower())
+    policy_config_name = utils.get_id(name.lower(), 15)
     #  test length of policy name
     # make sure name is not something that already exists
     if e_uci.get('mwan3', policy_config_name, default=None) is not None:

--- a/src/nethsec/mwan/__init__.py
+++ b/src/nethsec/mwan/__init__.py
@@ -185,14 +185,15 @@ def store_policy(e_uci: EUci, name: str, interfaces: list[dict]) -> list[str]:
         list of changed configuration
 
     Raises:
-        ValidationError: if name is not unique or length name > 15
+        ValidationError: if name is not unique or length or get_id > 15
     """
     changed_config = []
+    if len(name) > 12:
+        # get_id add 3 more chars (ns_) to the name
+        raise ValidationError('name', 'length_15_max', name)
     # generate policy name
     policy_config_name = utils.get_id(name.lower())
     #  test length of policy name
-    if len(policy_config_name) > 15:
-        raise ValidationError('name', 'length_15_max', name)
     # make sure name is not something that already exists
     if e_uci.get('mwan3', policy_config_name, default=None) is not None:
         raise ValidationError('name', 'unique', name)

--- a/src/nethsec/mwan/__init__.py
+++ b/src/nethsec/mwan/__init__.py
@@ -141,10 +141,11 @@ def store_rule(e_uci: EUci, name: str, policy: str, protocol: str = None,
         name of the rule created
 
     Raises:
-        ValidationError if name is not unique, policy is not valid or length name > 15
+        ValidationError if name is not unique, policy is not valid or length get_id > 15
     """
     # check if the rule length  is not more than 15 characters
-    if len(name) > 15:
+    if len(name) > 12:
+        # get_id add 3 more chars (ns_) to the name
         raise ValidationError('name', 'length_15_max', name)
     rule_config_name = utils.get_id(name.lower(), 15)
     rules = utils.get_all_by_type(e_uci, 'mwan3', 'rule').keys()

--- a/tests/test_mwan.py
+++ b/tests/test_mwan.py
@@ -323,6 +323,19 @@ def test_unique_rule(e_uci, mocker):
     assert e.value.args[0] == 'name'
     assert e.value.args[1] == 'unique'
 
+def test_rule_length(e_uci, mocker):
+    mocker.patch('subprocess.run')
+    mwan.store_policy(e_uci, 'default', [
+        {
+            'name': 'RED_1',
+            'metric': '20',
+            'weight': '100',
+        }
+    ])
+    with pytest.raises(ValidationError) as e:
+        mwan.store_rule(e_uci, 'nameisa15maxlength', 'ns_default')
+    assert e.value.args[0] == 'name'
+    assert e.value.args[1] == 'length'
 
 def test_missing_policy_rule(e_uci):
     with pytest.raises(ValidationError) as e:

--- a/tests/test_mwan.py
+++ b/tests/test_mwan.py
@@ -283,7 +283,7 @@ def test_policy_length(e_uci, mocker):
             }
         ])
     assert e.value.args[0] == 'name'
-    assert e.value.args[1] == 'length'
+    assert e.value.args[1] == 'length_15_max'
 
 def test_store_rule(e_uci, mocker):
     mocker.patch('subprocess.run')
@@ -294,17 +294,17 @@ def test_store_rule(e_uci, mocker):
             'weight': '100',
         }
     ])
-    assert mwan.store_rule(e_uci, 'additional rule', 'ns_default', 'udp', '192.168.1.1/24', '1:1024', '10.0.0.2/12',
-                           '22,443') == 'mwan3.ns_additional_r'
-    assert e_uci.get('mwan3', 'ns_additional_r') == 'rule'
-    assert e_uci.get('mwan3', 'ns_additional_r', 'label') == 'additional rule'
-    assert e_uci.get('mwan3', 'ns_additional_r', 'use_policy') == 'ns_default'
-    assert e_uci.get('mwan3', 'ns_additional_r', 'proto') == 'udp'
-    assert e_uci.get('mwan3', 'ns_additional_r', 'src_ip') == '192.168.1.1/24'
-    assert e_uci.get('mwan3', 'ns_additional_r', 'src_port') == '1:1024'
-    assert e_uci.get('mwan3', 'ns_additional_r', 'dest_ip') == '10.0.0.2/12'
-    assert e_uci.get('mwan3', 'ns_additional_r', 'dest_port') == '22,443'
-    assert e_uci.get('mwan3', 'ns_additional_r', 'sticky') == '0'
+    assert mwan.store_rule(e_uci, 'rule 1', 'ns_default', 'udp', '192.168.1.1/24', '1:1024', '10.0.0.2/12',
+                           '22,443') == 'mwan3.ns_rule_1'
+    assert e_uci.get('mwan3', 'ns_rule_1') == 'rule'
+    assert e_uci.get('mwan3', 'ns_rule_1', 'label') == 'rule 1'
+    assert e_uci.get('mwan3', 'ns_rule_1', 'use_policy') == 'ns_default'
+    assert e_uci.get('mwan3', 'ns_rule_1', 'proto') == 'udp'
+    assert e_uci.get('mwan3', 'ns_rule_1', 'src_ip') == '192.168.1.1/24'
+    assert e_uci.get('mwan3', 'ns_rule_1', 'src_port') == '1:1024'
+    assert e_uci.get('mwan3', 'ns_rule_1', 'dest_ip') == '10.0.0.2/12'
+    assert e_uci.get('mwan3', 'ns_rule_1', 'dest_port') == '22,443'
+    assert e_uci.get('mwan3', 'ns_rule_1', 'sticky') == '0'
 
 
 def test_unique_rule(e_uci, mocker):
@@ -317,8 +317,8 @@ def test_unique_rule(e_uci, mocker):
         }
     ])
     with pytest.raises(ValidationError) as e:
-        mwan.store_rule(e_uci, 'additional rule', 'ns_default')
-        mwan.store_rule(e_uci, 'additional rule', 'ns_default')
+        mwan.store_rule(e_uci, 'rule 1', 'ns_default')
+        mwan.store_rule(e_uci, 'rule 1', 'ns_default')
 
     assert e.value.args[0] == 'name'
     assert e.value.args[1] == 'unique'
@@ -335,7 +335,8 @@ def test_rule_length(e_uci, mocker):
     with pytest.raises(ValidationError) as e:
         mwan.store_rule(e_uci, 'nameisa15maxlength', 'ns_default')
     assert e.value.args[0] == 'name'
-    assert e.value.args[1] == 'length'
+    assert e.value.args[1] == 'length_15_max'
+
 
 def test_missing_policy_rule(e_uci):
     with pytest.raises(ValidationError) as e:
@@ -422,7 +423,7 @@ def test_index_rules(e_uci, mocker):
             'weight': '100',
         }
     ])
-    mwan.store_rule(e_uci, 'additional rule', 'ns_default')
+    mwan.store_rule(e_uci, 'rule 1', 'ns_default')
     index = mwan.index_rules(e_uci)
     assert index[0] == {
         'name': 'ns_default_rule',
@@ -433,8 +434,8 @@ def test_index_rules(e_uci, mocker):
         }
     }
     assert index[1] == {
-        'name': 'ns_additional_r',
-        'label': 'additional rule',
+        'name': 'ns_rule_1',
+        'label': 'rule 1',
         'policy': {
             'name': 'ns_default',
             'label': 'default',
@@ -456,9 +457,9 @@ def test_delete_rule(e_uci, mocker):
             'weight': '100',
         }
     ])
-    mwan.store_rule(e_uci, 'additional rule', 'ns_default')
-    assert mwan.delete_rule(e_uci, 'ns_additional_r') == 'mwan3.ns_additional_r'
-    assert 'ns_additional_r' not in e_uci.get_all('mwan3').keys()
+    mwan.store_rule(e_uci, 'rule 1', 'ns_default')
+    assert mwan.delete_rule(e_uci, 'ns_rule_1') == 'mwan3.ns_rule_1'
+    assert 'ns_rule_1' not in e_uci.get_all('mwan3').keys()
 
 
 def test_edit_rule(e_uci, mocker):

--- a/tests/test_mwan.py
+++ b/tests/test_mwan.py
@@ -267,6 +267,23 @@ def test_list_policies(e_uci, mocker):
     assert index[2]['members'][20][0]['metric'] == '20'
     assert index[2]['members'][20][0]['weight'] == '100'
 
+def test_policy_length(e_uci, mocker):
+    mocker.patch('subprocess.run')
+    with pytest.raises(ValidationError) as e:
+        assert mwan.store_policy(e_uci, 'nameisa15maxlength', [
+            {
+                'name': 'RED_1',
+                'metric': '10',
+                'weight': '200',
+            },
+            {
+                'name': 'RED_2',
+                'metric': '20',
+                'weight': '100',
+            }
+        ])
+    assert e.value.args[0] == 'name'
+    assert e.value.args[1] == 'length'
 
 def test_store_rule(e_uci, mocker):
     mocker.patch('subprocess.run')

--- a/tests/test_mwan.py
+++ b/tests/test_mwan.py
@@ -283,7 +283,7 @@ def test_policy_length(e_uci, mocker):
             }
         ])
     assert e.value.args[0] == 'name'
-    assert e.value.args[1] == 'length_15_max'
+    assert e.value.args[1] == 'length_12_max'
 
 def test_store_rule(e_uci, mocker):
     mocker.patch('subprocess.run')
@@ -335,7 +335,7 @@ def test_rule_length(e_uci, mocker):
     with pytest.raises(ValidationError) as e:
         mwan.store_rule(e_uci, 'nameisa15maxlength', 'ns_default')
     assert e.value.args[0] == 'name'
-    assert e.value.args[1] == 'length_15_max'
+    assert e.value.args[1] == 'length_12_max'
 
 
 def test_missing_policy_rule(e_uci):


### PR DESCRIPTION
This pull request fixes a validation issue in the `store_rule` and `store_policy` functions. Previously, the functions did not validate the length of the name parameter, which could lead to errors. This PR adds a check to ensure that the name length is not greater than 15 characters. If the length exceeds 15 characters, a `ValidationError` is raised. This improvement ensures that the functions handle name length validation correctly and prevents potential issues.

https://github.com/NethServer/nethsecurity/issues/556

the PR does not need to validate [A-Z,a-z,0-9,_] because get_id sanitizes it https://github.com/NethServer/python3-nethsec/blob/923b5b4c2bdee128249a4d09ca26c402399aef57/src/nethsec/utils/__init__.py#L60


NOTE: 
- we need to test the ID and not only the name because the ID is `ns_`+name 
`Jun  3 14:04:11 NethSec mwan3-init[13290]: Policy ns_123456789012345 exceeds max of 15 chars. Not setting policy`