### PR TITLE
utils: fix get_interface_from_device

### DIFF
--- a/src/nethsec/utils/__init__.py
+++ b/src/nethsec/utils/__init__.py
@@ -147,6 +147,8 @@ def get_interface_from_device(uci, device):
                 continue
             if proto == 'bonding' and section == device:
                 return section
+            if proto == 'pppoe' and section == device.removeprefix('pppoe-'):
+                return section
             try:
                 sdevice = uci.get("network", section, 'device')
             except:


### PR DESCRIPTION
Previously, the function was not returning the interface associated to a PPPoE device

NethServer/nethsecurity#571