### PR TITLE
Replace hyphens with colons in MWAN source and destination ports

### DIFF
--- a/src/nethsec/mwan/__init__.py
+++ b/src/nethsec/mwan/__init__.py
@@ -166,11 +166,11 @@ def store_rule(e_uci: EUci, name: str, policy: str, protocol: str = None,
     if source_address is not None:
         e_uci.set('mwan3', rule_config_name, 'src_ip', source_address)
     if source_port is not None:
-        e_uci.set('mwan3', rule_config_name, 'src_port', source_port)
+        e_uci.set('mwan3', rule_config_name, 'src_port', source_port.replace('-', ':'))
     if destination_address is not None:
         e_uci.set('mwan3', rule_config_name, 'dest_ip', destination_address)
     if destination_port is not None:
-        e_uci.set('mwan3', rule_config_name, 'dest_port', destination_port)
+        e_uci.set('mwan3', rule_config_name, 'dest_port', destination_port.replace('-', ':'))
 
     e_uci.save('mwan3')
     order_rules(e_uci, [rule_config_name] + list(rules))
@@ -419,11 +419,11 @@ def index_rules(e_uci: EUci) -> list[dict]:
         if 'src_ip' in rule_value:
             rule_data['source_address'] = rule_value['src_ip']
         if 'src_port' in rule_value:
-            rule_data['source_port'] = rule_value['src_port']
+            rule_data['source_port'] = rule_value['src_port'].replace(':', '-')
         if 'dest_ip' in rule_value:
             rule_data['destination_address'] = rule_value['dest_ip']
         if 'dest_port' in rule_value:
-            rule_data['destination_port'] = rule_value['dest_port']
+            rule_data['destination_port'] = rule_value['dest_port'].replace(':', '-')
         if 'sticky' in rule_value:
             rule_data['sticky'] = rule_value['sticky'] == '1'
 
@@ -530,9 +530,9 @@ def edit_rule(e_uci: EUci, name: str, policy: str, label: str, protocol: str = N
             e_uci.delete('mwan3', name, 'dest_port')
         else:
             if destination_port is not None:
-                e_uci.set('mwan3', name, 'dest_port', destination_port)
+                e_uci.set('mwan3', name, 'dest_port', destination_port.replace('-', ':'))
             if source_port is not None:
-                e_uci.set('mwan3', name, 'src_port', source_port)
+                e_uci.set('mwan3', name, 'src_port', source_port.replace('-', ':'))
     if source_address is not None:
         e_uci.set('mwan3', name, 'src_ip', source_address)
     if destination_address is not None:

--- a/tests/test_mwan.py
+++ b/tests/test_mwan.py
@@ -294,7 +294,7 @@ def test_store_rule(e_uci, mocker):
             'weight': '100',
         }
     ])
-    assert mwan.store_rule(e_uci, 'rule 1', 'ns_default', 'udp', '192.168.1.1/24', '1:1024', '10.0.0.2/12',
+    assert mwan.store_rule(e_uci, 'rule 1', 'ns_default', 'udp', '192.168.1.1/24', '1-1024', '10.0.0.2/12',
                            '22,443', True) == 'mwan3.ns_rule_1'
     assert e_uci.get('mwan3', 'ns_rule_1') == 'rule'
     assert e_uci.get('mwan3', 'ns_rule_1', 'label') == 'rule 1'
@@ -305,7 +305,6 @@ def test_store_rule(e_uci, mocker):
     assert e_uci.get('mwan3', 'ns_rule_1', 'dest_ip') == '10.0.0.2/12'
     assert e_uci.get('mwan3', 'ns_rule_1', 'dest_port') == '22,443'
     assert e_uci.get('mwan3', 'ns_rule_1', 'sticky') == '1'
-
 
 def test_unique_rule(e_uci, mocker):
     mocker.patch('subprocess.run')
@@ -498,7 +497,7 @@ def test_edit_rule(e_uci, mocker):
     assert e_uci.get('mwan3', 'ns_default_rule', 'src_ip') == '192.168.10.1/12'
     assert e_uci.get('mwan3', 'ns_default_rule', 'src_port') == '80,443'
     assert e_uci.get('mwan3', 'ns_default_rule', 'dest_ip') == '0.0.0.0/0'
-    assert e_uci.get('mwan3', 'ns_default_rule', 'dest_port') == '4040-8080'
+    assert e_uci.get('mwan3', 'ns_default_rule', 'dest_port') == '4040:8080'
 
 
 def test_cant_edit_invalid_rule(e_uci, mocker):


### PR DESCRIPTION
This pull request replaces hyphens with colons in the source and destination ports of the MWAN module. This ensures consistency and compatibility with other parts of the codebase.

https://github.com/NethServer/nethsecurity/issues/580