### PR TITLE
users: fix description unwanted update

### DIFF
--- a/src/nethsec/users/__init__.py
+++ b/src/nethsec/users/__init__.py
@@ -468,7 +468,7 @@ def add_local_user(uci, name, password="", description="", database="main", extr
     uci.save("users")
     return id
 
-def edit_local_user(uci, name, password="", description="", database="main", extra_fields={}):
+def edit_local_user(uci, name, password="", description=None, database="main", extra_fields={}):
     '''
     Edit an existing local user
 
@@ -476,7 +476,7 @@ def edit_local_user(uci, name, password="", description="", database="main", ext
       - uci -- EUci pointer
       - name -- User name
       - password -- User password
-      - description -- User description (default: "")
+      - description -- User description (default: None)
       - database -- Local database identifier (default: main)
       - extra_fields -- Extra fields to add to the user (default: {})
 
@@ -497,7 +497,8 @@ def edit_local_user(uci, name, password="", description="", database="main", ext
               if uci.get('rpcd', l, 'username', default='') == name:
                   uci.set('rpcd', l, 'password', shadow)
                   uci.save("rpcd")
-    uci.set('users', user["id"], 'description', description)
+    if description is not None:
+        uci.set('users', user["id"], 'description', description)
     for key in uci.get_all('users', user["id"]):
         if not key in ["name", "description", "password", "database"]:
             uci.delete('users', user["id"], key)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -318,7 +318,7 @@ def test_add_local_user(tmp_path):
 
 def test_edit_local_user(tmp_path):
     u = _setup_db(tmp_path)
-    id = users.edit_local_user(u, "t1", password="pass2", description="mydesc2", database="second", extra_fields={"openvpn_ipaddr": "1.2.3.5", "openvpn_enabled": "1"})
+    id = users.edit_local_user(u, "t1", password="pass2", description='mydesc2', database="second", extra_fields={"openvpn_ipaddr": "1.2.3.5", "openvpn_enabled": "1"})
     user = users.get_user_by_name(u, "t1", "second")
     assert users.check_password("pass2", user.pop("password"))
     assert user == {
@@ -331,7 +331,10 @@ def test_edit_local_user(tmp_path):
         "openvpn_ipaddr": "1.2.3.5",
         "openvpn_enabled": "1"
     }
-    id = users.edit_local_user(u, "t1", password="pass2", description="mydesc2", database="second", extra_fields={"openvpn_enabled": "1"})
+    # make sure description is not changed if not passed as parameter
+    id = users.edit_local_user(u, "t1", password="pass2", database="second", extra_fields={"openvpn_ipaddr": "1.2.3.5", "openvpn_enabled": "1"})
+    assert u.get('users', id, 'description') == 'mydesc2'
+    id = users.edit_local_user(u, "t1", password="pass2",  database="second", extra_fields={"openvpn_enabled": "1"})
     with pytest.raises(UciExceptionNotFound) as e:
         assert u.get('users', id, 'openvpn_ipaddr')
 


### PR DESCRIPTION
If the description field is not passed as parameter, the value of the field must be preserved

NethServer/nethsecurity#592