### PR TITLE
fix(mwan): wrong type labeling for policies

### DIFF
--- a/src/nethsec/mwan/__init__.py
+++ b/src/nethsec/mwan/__init__.py
@@ -287,7 +287,9 @@ def index_policies(e_uci: EUci) -> list[dict]:
 
         # infer policy type by metrics
         metrics = [int(member['metric']) for member in members]
-        if all(metric == metrics[0] for metric in metrics):
+        if len(metrics) == 1:
+            policy_data['type'] = 'custom'
+        elif all(metric == metrics[0] for metric in metrics):
             policy_data['type'] = 'balance'
         elif all(metrics.index(metric) == key for key, metric in enumerate(metrics)):
             policy_data['type'] = 'backup'

--- a/tests/test_mwan.py
+++ b/tests/test_mwan.py
@@ -524,3 +524,15 @@ def test_cant_edit_invalid_rule(e_uci, mocker):
     assert e.value.args[0] == 'policy'
     assert e.value.args[1] == 'invalid'
     assert e.value.args[2] == 'ns_cool_policy'
+
+
+def test_policy_type(e_uci, mocker):
+    mocker.patch('subprocess.run')
+    mwan.store_policy(e_uci, 'custom', [
+        {
+            'name': 'RED_3',
+            'metric': '10',
+            'weight': '200',
+        }
+    ])
+    assert mwan.index_policies(e_uci)[0]['type'] == 'custom'


### PR DESCRIPTION
Fixing issue where mwan can be labeled incorrectly when only one interface is configured

Ref:
 - https://github.com/NethServer/nethsecurity/issues/606
