### PR TITLE
reverse_proxy: remove X-Forwarded-Proto header

### DIFF
--- a/src/nethsec/reverse_proxy/__init__.py
+++ b/src/nethsec/reverse_proxy/__init__.py
@@ -67,7 +67,6 @@ def create_location(e_uci, uci_server, location, proxy_pass, domain=''):
     # defaults
     e_uci.set('nginx', location_id, 'proxy_http_version', '1.1')
     default_headers = [
-        'X-Forwarded-Proto $scheme',
         'X-Forwarded-For $proxy_add_x_forwarded_for',
         'X-Real-IP $remote_addr',
         'Upgrade $http_upgrade',


### PR DESCRIPTION
This header is a de-facto standard. Still, some applications may not work correctly with it, notably WebTop.
Remove the header from new reverse_proxy configuration to have the same behavior of NethServer 7: this should prevent regressions.

NethServer/nethsecurity#622