### PR TITLE
reverse_proxy: increase max_body_size

### DIFF
--- a/src/nethsec/reverse_proxy/__init__.py
+++ b/src/nethsec/reverse_proxy/__init__.py
@@ -76,6 +76,8 @@ def create_location(e_uci, uci_server, location, proxy_pass, domain=''):
     if domain:
         default_headers.append(f'Host {domain}')
     e_uci.set('nginx', location_id, 'proxy_set_header', default_headers)
+    # set body limit to 1GB: same value of NethServer 7
+    e_uci.set('nginx', location_id, 'client_max_body_size', '1024MB')
     # setup location
     e_uci.set('nginx', location_id, 'uci_server', uci_server)
     e_uci.set('nginx', location_id, 'location', location)


### PR DESCRIPTION
By default, max_body_size is 1MB which is different from NethServer 7 were the maximum size was set to 1GB.

Raise the limit to 1GB for new reverse proxies to retain the old behavior and limit regressions.