### PR TITLE
Fixes for Mwan objects

### DIFF
--- a/src/nethsec/mwan/__init__.py
+++ b/src/nethsec/mwan/__init__.py
@@ -602,12 +602,20 @@ def edit_rule(e_uci: EUci, name: str, policy: str, label: str, protocol: str = N
                 e_uci.set('mwan3', name, 'src_port', source_port.replace('-', ':'))
     if source_address is not None:
         e_uci.set('mwan3', name, 'src_ip', source_address)
+    else:
+        e_uci.delete('mwan3', name, 'src_ip')
     if destination_address is not None:
         e_uci.set('mwan3', name, 'dest_ip', destination_address)
+    else:
+        e_uci.delete('mwan3', name, 'dest_ip')
     if ns_src is not None:
         e_uci.set('mwan3', name, 'ns_src', ns_src)
+    else:
+        e_uci.delete('mwan3', name, 'ns_src')
     if ns_dst is not None:
         e_uci.set('mwan3', name, 'ns_dst', ns_dst)
+    else:
+        e_uci.delete('mwan3', name, 'ns_dst')
     update_rules(e_uci) # update rules with objects and save mwan3 config
     return f'mwan3.{name}'
 

--- a/src/nethsec/objects/__init__.py
+++ b/src/nethsec/objects/__init__.py
@@ -776,12 +776,14 @@ def list_dns_records(uci, expand=False, used_info=False):
             records.append(record)
     return records
 
-def list_objects(uci, include_domain_sets=True, singleton_only=False, expand=False):
+def list_objects(uci, include_domain_sets=True, include_host_sets=True, singleton_only=False, expand=False):
     """
     Get objects from objects, dhcp, and users config
 
     Args:
         uci: EUci pointer
+        include_domain_sets: include domain sets in the list
+        include_host_sets: include host sets in the list
         expand: expand the list with all IP addresses of the object
 
     Returns:
@@ -789,14 +791,15 @@ def list_objects(uci, include_domain_sets=True, singleton_only=False, expand=Fal
     """
     hsets = []
     dsets = []
-    for h in list_host_sets(uci, True):
-        if singleton_only and not h['singleton']:
-            continue
-        h['id'] = f"objects/{h['id']}"
-        h['type'] = 'host_set'
-        if not expand:
-            del[h['ipaddr']]
-        hsets.append(h)
+    if include_host_sets:
+        for h in list_host_sets(uci, True):
+            if singleton_only and not h['singleton']:
+                continue
+            h['id'] = f"objects/{h['id']}"
+            h['type'] = 'host_set'
+            if not expand:
+                del[h['ipaddr']]
+            hsets.append(h)
 
     if include_domain_sets:
         for d in list_domain_sets(uci, True):


### PR DESCRIPTION
Refactored `list_objects` allowing to exclude hosts_sets, will be used by `ns.objects` to have a more standardized experience with objects.
Adding removal of not used property when editing a MWAN, was causing issues.

Ref:
 -  https://github.com/NethServer/nethsecurity/issues/671
 
