### PR TITLE
mwan: fix object support

### DIFF
--- a/src/nethsec/objects/__init__.py
+++ b/src/nethsec/objects/__init__.py
@@ -827,20 +827,23 @@ def get_info(uci, database_id):
 
     Returns:
         a dictionary with the following fields:
+
         - `database`: the database of the object
         - `id`: the id of the object
         - `name`: the name of the object
         - `type`: the type of the object
+        - `family`: IP family, like `ipv4` or `ipv6`
     """
     try:
         database, id = database_id.split('/')
         type = uci.get(database, id)
         name = uci.get(database, id, 'name', default=None)
+        family = uci.get(database, id, 'family', default='ipv4')
         if not name:
             name = uci.get(database, id, 'label', default=None)
             if not name:
                 name = id
-        return {'database': database, 'id': id, 'name': name, 'type': type}
+        return {'database': database, 'id': id, 'name': name, 'type': type, 'family': family}
     except:
         return None
         

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -22,6 +22,11 @@ config host 'ns_12345'
 	option name 'h1'
 	option family 'ipv4'
 	list ipaddr 'dhcp/ns_112233'
+
+config host 'ns_a7439990'
+	option name 'h1v6'
+	option family 'ipv6'
+	list ipaddr 'fd:618c:d80a:dc82:2380:54c7:7a17:1013'
 """
 
 firewall_db = """
@@ -243,7 +248,7 @@ def test_is_used_host_set(u):
 
 def test_list_host_sets(u):
     sets = objects.list_host_sets(u)
-    assert len(sets) == 9
+    assert len(sets) == 10
 
 def test_is_singleton_host_set(u):
     id1 = objects.add_host_set(u, "myhostset", "ipv4", ["1.2.3.4", "5.6.7.8"])
@@ -362,7 +367,13 @@ def test_get_reference_info(u):
     assert ref['type'] == 'host'
     assert ref['name'] == 'host2'
     assert ref['id'] == 'ns_8dcab636'
+    assert ref['family'] == 'ipv4'
     assert objects.get_info(u, "unknown") == None
+    ref2 = objects.get_info(u, "objects/ns_a7439990")
+    assert ref2['type'] == 'host'
+    assert ref2['name'] == 'h1v6'
+    assert ref2['id'] == 'ns_a7439990'
+    assert ref2['family'] == 'ipv6'
  
 def test_is_object_with_invalid_is(u):
     assert objects.is_object_id(None) == False


### PR DESCRIPTION
- remove domain set support
- prevent usage of IPv6 objects

References:
- Issue: NethServer/nethsecurity#671
- Changes used by: https://github.com/NethServer/nethsecurity/pull/712