### PR TITLE
conntrack: make sure counters is set

### DIFF
--- a/src/nethsec/conntrack/__init__.py
+++ b/src/nethsec/conntrack/__init__.py
@@ -13,7 +13,6 @@ import subprocess
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
 
-
 def __parse_meta_connection_tag(meta: Element) -> dict:
     """
     From a meta tag, extract the connection information.
@@ -24,7 +23,7 @@ def __parse_meta_connection_tag(meta: Element) -> dict:
     Returns:
         dictionary with the connection information.
     """
-    result = {}
+    result = {'src': '', 'dest': '', 'protocol': '', 'packets': '0', 'bytes': '0'}
     layer3 = meta.find('layer3')
     result['src'] = layer3.find('src').text
     result['dest'] = layer3.find('dst').text
@@ -36,8 +35,9 @@ def __parse_meta_connection_tag(meta: Element) -> dict:
     if layer4.find('dport') is not None:
         result['end_port'] = layer4.find('dport').text
     counters = meta.find('counters')
-    result['packets'] = counters.find('packets').text
-    result['bytes'] = counters.find('bytes').text
+    if counters is not None:
+        result['packets'] = counters.find('packets').text
+        result['bytes'] = counters.find('bytes').text
     return result
 
 


### PR DESCRIPTION
Avoid error like:
```
  File "/usr/lib/python3.11/site-packages/nethsec/conntrack/__init__.py", line 39, in __parse_meta_connection_tag
    result['packets'] = counters.find('packets').text
                        ^^^^^^^^^^^^^
  AttributeError: 'NoneType' object has no attribute 'find'
```

The error could be caused by a connection like this one:
```
unknown  2 598 src=0.0.0.0 dst=224.0.0.1 [UNREPLIED] src=224.0.0.1 dst=0.0.0.0 mark=0 use=1
```