### PR TITLE
refactor: set to public load_protocols method

### DIFF
--- a/src/nethsec/dpi/__init__.py
+++ b/src/nethsec/dpi/__init__.py
@@ -68,7 +68,7 @@ def __load_application_categories() -> dict[int, dict[str]]:
     return categories
 
 
-def __load_protocols() -> dict[int, str]:
+def load_protocols() -> dict[int, str]:
     """
     Reads the protocols from the netifyd --dump-protos command.
 
@@ -142,7 +142,7 @@ def __load_blocklist() -> list[dict[str]]:
             result_application['category'] = application_categories[application_id]
         result.append(result_application)
 
-    protocols = __load_protocols()
+    protocols = load_protocols()
     protocol_categories = __load_protocol_categories()
 
     for protocol_id, protocol_name in protocols.items():

--- a/tests/test_dpi.py
+++ b/tests/test_dpi.py
@@ -377,7 +377,7 @@ def e_uci_with_data(e_uci: EUci):
 def mock_load(mocker):
     mocker.patch('nethsec.dpi.__load_applications', return_value=applications)
     mocker.patch('nethsec.dpi.__load_application_categories', return_value=application_categories)
-    mocker.patch('nethsec.dpi.__load_protocols', return_value=protocols)
+    mocker.patch('nethsec.dpi.load_protocols', return_value=protocols)
     mocker.patch('nethsec.dpi.__load_protocol_categories', return_value=protocol_categories)
 
 
@@ -402,7 +402,7 @@ def test_load_protocols(mocker: MockFixture):
     process_result = mocker.stub('subprocess_return')
     process_result.stdout = bytes(protocol_output, 'utf-8')
     mocker.patch('subprocess.run', return_value=process_result)
-    assert dpi.__load_protocols() == protocols
+    assert dpi.load_protocols() == protocols
 
 
 @pytest.mark.parametrize('search', [None, ''])


### PR DESCRIPTION
Publishing method `load_protocols`.

Change needed by https://github.com/NethServer/nethsecurity/pull/779
