### PR TITLE
fix(mwan): adding default last_resort when creating policy

### DIFF
--- a/src/nethsec/mwan/__init__.py
+++ b/src/nethsec/mwan/__init__.py
@@ -267,6 +267,10 @@ def store_policy(e_uci: EUci, name: str, interfaces: list[dict]) -> list[str]:
     if len(utils.get_all_by_type(e_uci, 'mwan3', 'rule')) == 0:
         changed_config.append(store_rule(e_uci, 'Default Rule', policy_config_name))
 
+    # default policy must have a last_resort field
+    if len(utils.get_all_by_type(e_uci, 'mwan3', 'policy')) == 1:
+        e_uci.set('mwan3', policy_config_name, 'last_resort', 'default')
+
     e_uci.save('mwan3')
     e_uci.save('network')
     return changed_config

--- a/tests/test_mwan.py
+++ b/tests/test_mwan.py
@@ -194,6 +194,7 @@ def test_create_default_mwan(e_uci, mocker):
     assert e_uci.get('mwan3', 'ns_default', 'label') == 'default'
     assert e_uci.get('mwan3', 'ns_default', 'use_member', list=True) == (
         'ns_RED_1_M10_W200', 'ns_RED_2_M20_W100')
+    assert e_uci.get('mwan3', 'ns_default', 'last_resort') == 'default'
 
 
 def test_create_unique_mwan(e_uci, mocker):


### PR DESCRIPTION
Ref:
- https://github.com/NethServer/nethsecurity/issues/853
