### PR TITLE
fix(users): force user name to lower case

### DIFF
--- a/src/nethsec/users/__init__.py
+++ b/src/nethsec/users/__init__.py
@@ -756,7 +756,7 @@ def ldif2users(ldif_data, user_attr="uid", display_attr="cn"):
     for dn, record in parser.parse():
         if user_attr in record:
             user = {}
-            user["name"] = record[user_attr][0]
+            user["name"] = record[user_attr][0].lower()
             if display_attr in record:
                 user["description"] = record[display_attr][0]
             else:


### PR DESCRIPTION
Users inside a remote LDAP are usually matched in case-insensitive mode.

Make sure to always force the username to lower case to avoid mismatch when the remote LDAP has names in uppercase (like AD): this change will fix access for OpenVPN users using the external LDAP.

Note that such users are already imported in lower case inside the users db.

NethServer/nethsecurity#966