### PR TITLE
Firewall: Allow any zone as valid input for is_zone function

### DIFF
--- a/src/nethsec/firewall/__init__.py
+++ b/src/nethsec/firewall/__init__.py
@@ -1219,13 +1219,13 @@ def list_rules(uci, rule_type = None) -> list:
             else:
                 if rule_type =='forward' and is_forward_rule(rule):
                    rules.append(enrich_rule(uci, rule))
-                   rule['active_zone'] = is_zone(uci, rule['src']) and is_zone(uci, rule['dest']) 
+                   rule['active_zone'] = is_zone(uci, rule.get('src','*')) and is_zone(uci, rule.get('dest','*')) 
                 elif rule_type =='input' and is_input_rule(rule):
                    rules.append(enrich_rule(uci, rule))
-                   rule['active_zone'] = is_zone(uci, rule['src'])
+                   rule['active_zone'] = is_zone(uci, rule.get('src','*'))
                 elif rule_type =='output' and is_output_rule(rule):
                    rules.append(enrich_rule(uci, rule))
-                   rule['active_zone'] = is_zone(uci, rule['dest'])
+                   rule['active_zone'] = is_zone(uci, rule.get('dest','*'))
         i += 1
     return rules
 

--- a/src/nethsec/firewall/__init__.py
+++ b/src/nethsec/firewall/__init__.py
@@ -1187,12 +1187,14 @@ def is_zone(uci, name:str) -> bool:
     Returns:
         True if name is a zone, False otherwise
     """
+
+    # True zone if name is 'any' zone name -> '*'
+    if name == '*':
+        return True
+
     zones = list_zones(uci)
     for value in zones.values():
         if 'name' in value and value['name'] == name:
-            return True
-        # True zone if name is 'any' zone name -> '*'
-        elif name == '*':
             return True
     return False
 

--- a/src/nethsec/firewall/__init__.py
+++ b/src/nethsec/firewall/__init__.py
@@ -1179,7 +1179,7 @@ def is_output_rule(rule: dict) -> bool:
 
 def is_zone(uci, name:str) -> bool:
     """
-    Check if name is a zone
+    Check if name is a zone or any zone ('*')
 
     Args:
         name: zone to check
@@ -1190,6 +1190,9 @@ def is_zone(uci, name:str) -> bool:
     zones = list_zones(uci)
     for value in zones.values():
         if 'name' in value and value['name'] == name:
+            return True
+        # True zone if name is 'any' zone name -> '*'
+        elif name == '*':
             return True
     return False
 

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -815,6 +815,16 @@ def test_resolve_address(u):
     assert firewall.resolve_address(u, "10.0.0.22") == {"value": "10.0.0.22", "type": "interface", "label": "bond1"}
     assert firewall.resolve_address(u, "2001:db80::2/64") == {"value": "2001:db80::2/64", "type": "interface", "label": "wan6"}
 
+def test_is_zone(u):
+    assert firewall.is_zone(u,"lan") == True
+    assert firewall.is_zone(u,"wan") == True
+    assert firewall.is_zone(u,"blue") == True
+    assert firewall.is_zone(u,"wan") == True
+    # we expect it fails because the zone does not exist
+    assert firewall.is_zone(u,"lan2custom") == False
+    # we expect it to be true because we are using any zone
+    assert firewall.is_zone(u,"*") == True
+
 def test_list_forward_rules(u):
     rules = firewall.list_forward_rules(u)
     assert len(rules) > 0
@@ -826,6 +836,7 @@ def test_list_forward_rules(u):
         assert 'enabled' in r
         assert 'ns_tag' in r
         assert 'proto' in r
+        assert 'active_zone' in r
 
 def test_list_output_rules(u):
     rules = firewall.list_output_rules(u)
@@ -838,6 +849,7 @@ def test_list_output_rules(u):
        assert 'enabled' in r
        assert 'ns_tag' in r
        assert 'proto' in r
+       assert 'active_zone' in r
 
 def test_list_input_rules(u):
     rules = firewall.list_input_rules(u)
@@ -850,6 +862,7 @@ def test_list_input_rules(u):
        assert 'enabled' in r
        assert 'ns_tag' in r
        assert 'proto' in r
+       assert 'active_zone' in r
 
 def test_list_service_suggestions(u, mocker):
     mocker.patch('builtins.open', mocker.mock_open(read_data=services_file))


### PR DESCRIPTION
Update the `is_zone` function to recognize '*' as a valid zone name, enhancing its flexibility in zone validation.

https://github.com/NethServer/nethsecurity/issues/1012