### PR TITLE
feat(inventory): track new Snort, WireGuard and MAC binding features

### DIFF
--- a/src/nethsec/inventory/__init__.py
+++ b/src/nethsec/inventory/__init__.py
@@ -499,3 +499,15 @@ def fact_snort(uci: EUci):
     except:
         pass
     return ret
+
+def fact_mac_ip_binding(uci: EUci):
+    ret = { "disabled": 0, "soft-binding": 0, "hard-binding": 0 }
+    # Parse DHCP servers
+    for section in utils.get_all_by_type(uci, 'dhcp', 'dhcp'):
+        if uci.get('dhcp', section, 'ns_binding', default='') == '' or uci.get('dhcp', section, 'ns_binding', default='') == '0':
+            ret['disabled'] += 1  # Increment the count for DHCP servers
+        elif uci.get('dhcp', section, 'ns_binding', default='') == '1':
+            ret['soft-binding'] += 1
+        elif uci.get('dhcp', section, 'ns_binding', default='') == '2':
+            ret['hard-binding'] += 1
+    return ret

--- a/src/nethsec/inventory/__init__.py
+++ b/src/nethsec/inventory/__init__.py
@@ -471,33 +471,19 @@ def fact_wiregard(uci: EUci):
 def fact_snort(uci: EUci):
     ret = { 'enabled': False, 'policy': '', 'oink_enabled': False, 'disabled_rules': 0, 'bypass_src_ipv4': 0, 'bypass_src_ipv6': 0, 'bypass_dst_ipv4': 0, 'bypass_dst_ipv6': 0 }
 
-    ret['enabled'] = uci.get('snort', 'snort', 'enabled', default='0') == '1'
+    ret['enabled'] = uci.get('snort', 'snort', 'enabled', dtype=bool, default=False)
     ret['policy'] = uci.get('snort', 'snort', 'ns_policy', default='')
     ret['oink_enabled'] = True if uci.get('snort', 'snort', 'oinkcode', default='') else False
 
     # count list of ns_disabled_rules
-    try :
-        ret['disabled_rules'] = len(uci.get_all('snort', 'snort', 'ns_disabled_rules'))
-    except:
-        pass
+    ret['disabled_rules'] = len(uci.get('snort', 'snort', 'ns_disabled_rules', list=True, default=[]))
     # count the source bypass of ipv4 and ipv6
-    try:
-        ret['bypass_src_ipv4'] = len(uci.get_all('snort', 'nfq', 'bypass_src_v4'))
-    except:
-        pass
-    try:
-        ret['bypass_src_ipv6'] = len(uci.get_all('snort', 'nfq', 'bypass_src_v6'))
-    except:
-        pass
-    ## count the destination bypass_dst_v4 and bypass_dst_]
-    try:
-        ret['bypass_dst_ipv4'] = len(uci.get_all('snort', 'nfq', 'bypass_dst_v4'))
-    except:
-        pass
-    try:
-        ret['bypass_dst_ipv6'] = len(uci.get_all('snort', 'nfq', 'bypass_dst_v6'))
-    except:
-        pass
+    ret['bypass_src_ipv4'] = len(uci.get('snort', 'nfq', 'bypass_src_v4', list=True, default=[]))
+    ret['bypass_src_ipv6'] = len(uci.get('snort', 'nfq', 'bypass_src_v6', list=True, default=[]))
+    ## count the destination bypass_dst_v4 and bypass_dst_ipv6
+    ret['bypass_dst_ipv4'] = len(uci.get('snort', 'nfq', 'bypass_dst_v4', list=True, default=[]))
+    ret['bypass_dst_ipv6'] = len(uci.get('snort', 'nfq', 'bypass_dst_v6', list=True, default=[]))
+
     return ret
 
 def fact_mac_ip_binding(uci: EUci):

--- a/src/nethsec/inventory/__init__.py
+++ b/src/nethsec/inventory/__init__.py
@@ -462,8 +462,40 @@ def fact_wiregard(uci: EUci):
                user_db.update({i:interface.get('ns_user_db')})
     ## iterate over all wireguard interfaces from wg
     ## find the number of peers from wireguard_wg1
-    for interface in wg:
-        peers = utils.get_all_by_type(uci, "network", 'wireguard_'+interface)
-        ret['statistics'].append({'server': interface, "peers": len(peers), "ns_user_db": user_db[interface]})
+    for w in wg:
+        peers = utils.get_all_by_type(uci, "network", 'wireguard_'+w)
+        ret['statistics'].append({'server': w, "peers": len(peers), "ns_user_db": user_db[w]})
     return ret
 
+
+def fact_snort(uci: EUci):
+    ret = { 'enabled': False, 'policy': '', 'oink_enabled': False, 'disabled_rules': 0, 'bypass_src_ipv4': 0, 'bypass_src_ipv6': 0, 'bypass_dst_ipv4': 0, 'bypass_dst_ipv6': 0 }
+
+    ret['enabled'] = uci.get('snort', 'snort', 'enabled', default='0') == '1'
+    ret['policy'] = uci.get('snort', 'snort', 'ns_policy', default='')
+    ret['oink_enabled'] = True if uci.get('snort', 'snort', 'oinkcode', default='') else False
+
+    # count list of ns_disabled_rules
+    try :
+        ret['disabled_rules'] = len(uci.get_all('snort', 'snort', 'ns_disabled_rules'))
+    except:
+        pass
+    # count the source bypass of ipv4 and ipv6
+    try:
+        ret['bypass_src_ipv4'] = len(uci.get_all('snort', 'nfq', 'bypass_src_v4'))
+    except:
+        pass
+    try:
+        ret['bypass_src_ipv6'] = len(uci.get_all('snort', 'nfq', 'bypass_src_v6'))
+    except:
+        pass
+    ## count the destination bypass_dst_v4 and bypass_dst_]
+    try:
+        ret['bypass_dst_ipv4'] = len(uci.get_all('snort', 'nfq', 'bypass_dst_v4'))
+    except:
+        pass
+    try:
+        ret['bypass_dst_ipv6'] = len(uci.get_all('snort', 'nfq', 'bypass_dst_v6'))
+    except:
+        pass
+    return ret

--- a/src/nethsec/inventory/__init__.py
+++ b/src/nethsec/inventory/__init__.py
@@ -446,3 +446,24 @@ def fact_ddns(uci: EUci):
 def fact_snmp (uci: EUci):
     snmp = _run_status("/etc/init.d/snmpd running")
     return { 'enabled': snmp == 0 }
+
+def fact_wiregard(uci: EUci):
+    ret = { 'instances': 0, 'statistics':[] }
+    wg= []
+    user_db = {}
+    interfaces = utils.get_all_by_type(uci, "network", "interface")
+    for i in interfaces:
+        interface = interfaces[i]
+        if interface.get("proto") == "wireguard":
+           wg.append(i)
+           ret['instances'] += 1
+           user_db.update({i:'main'})
+           if interface.get("ns_user_db"):
+               user_db.update({i:interface.get('ns_user_db')})
+    ## iterate over all wireguard interfaces from wg
+    ## find the number of peers from wireguard_wg1
+    for interface in wg:
+        peers = utils.get_all_by_type(uci, "network", 'wireguard_'+interface)
+        ret['statistics'].append({'server': interface, "peers": len(peers), "ns_user_db": user_db[interface]})
+    return ret
+


### PR DESCRIPTION
Implement functionality to retrieve and return statistics for WireGuard interfaces, including the number of instances and peers associated with each interface.



https://github.com/NethServer/nethsecurity/issues/987

```json
    "wiregard": {
      "instances": 2,
      "statistics": [
        {
          "server": "wg1",
          "peers": 2,
          "ns_user_db": "main"
        },
        {
          "server": "wg2",
          "peers": 0,
          "ns_user_db": "ldap"
        }
      ]
    },


    "mac_ip_binding": {
      "disabled": 1,
      "soft-binding": 0,
      "hard-binding": 1
    },


    "snort": {
      "enabled": true,
      "policy": "security",
      "oink_enabled": false,
      "disabled_rules": 2,
      "bypass_src_ipv4": 2,
      "bypass_src_ipv6": 0,
      "bypass_dst_ipv4": 0,
      "bypass_dst_ipv6": 0
    },

```