### PR TITLE
fix(users): ignore username case

### DIFF
--- a/src/nethsec/users/__init__.py
+++ b/src/nethsec/users/__init__.py
@@ -55,7 +55,7 @@ def get_user_by_name(uci, name, database="main"):
         if uci.get('users', u, 'database', default='') != database:
             continue
         if uci.get('users', u, default='') == "user":
-            if uci.get('users', u, 'name', default='') == name:
+            if uci.get('users', u, 'name', default='').lower() == name.lower():
                 for opt in uci.get_all("users", u):
                     user[opt] = uci.get_all('users', u, opt)
                     # convert tuple to list


### PR DESCRIPTION
Ignore username case when looking for a user inside users database.

**NOTE**
This change will make username validation more restrictive: two or more users with the same name but different case (e.g. `Goofy` and `goofy`) won't be allowed anymore.

Ref:
- https://github.com/NethServer/nethsecurity/issues/1039