### PR TITLE
fix(inventory): inventory couldn't be sent due to missing config

### DIFF
--- a/src/nethsec/inventory/__init__.py
+++ b/src/nethsec/inventory/__init__.py
@@ -512,6 +512,10 @@ def fact_backups(uci: EUci):
 
 def fact_ha(uci: EUci):
     vrrp_instances = utils.get_all_by_type(uci, 'keepalived', 'vrrp_instance')
+    if vrrp_instances is None:
+        vrrp_instances = []
     ipaddresses = utils.get_all_by_type(uci, 'keepalived', 'ipaddress')
+    if ipaddresses is None:
+        ipaddresses = []
 
     return { 'enabled': len(vrrp_instances) > 0, 'vips': len(ipaddresses) }


### PR DESCRIPTION
If you have a 1.5.1 updated with the latest packages, inventory couldn't be sent due to missing configuration.
The ubus calls return None, that don't have a `length`, which caused the sync to fail.
