### PR TITLE
feat(inventory): report extra installed packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name = 'nethsec',
-    version = '1.7.1',
+    version = '1.8.0',
     author = 'Giacomo Sanchietti',
     author_email = 'giacomo.sanchietti@nethesis.it',
     description = 'Utilities for NethSecurity development',

--- a/src/nethsec/inventory/__init__.py
+++ b/src/nethsec/inventory/__init__.py
@@ -19,6 +19,9 @@ import hashlib
 from socket import inet_ntoa
 from struct import pack
 
+APK_WORLD = '/etc/apk/world'
+APK_WORLD_BASE = '/rom/etc/apk/world'
+
 ## Utilities
 
 def _run(cmd):
@@ -85,6 +88,21 @@ def _get_cpu_field(field, cpu_info):
             return f['data']
 
     return ''
+
+def _read_apk_world(path):
+    names = set()
+    try:
+        with open(path, 'r') as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#') or line.startswith('!'):
+                    continue
+                name = re.split(r'[<>=~]', line, maxsplit=1)[0].strip()
+                if name:
+                    names.add(name)
+    except:
+        pass
+    return names
 
 def anonymize(value, uci: EUci):
     if fact_subscription_status(uci).get('status', 'no') != "no":
@@ -591,6 +609,31 @@ def fact_dpi(uci: EUci):
         if uci.get('dpi', rule, 'enabled', default='0') == '1':
             ret["rules"] += 1
     return ret
+
+def fact_extra_packages(uci: EUci):
+    """
+    List the packages installed by the administrator on top of the base image.
+
+    The base image package set is read from /rom/etc/apk/world, the read-only
+    squashfs lower layer, while the current one is read from /etc/apk/world.
+    Since 'apk add <pkg>' appends only <pkg> itself, and not its dependencies,
+    the difference between the two files is the set of packages explicitly
+    installed after the image was built.
+    If the base world file is missing or unreadable, no package is reported:
+    this avoids reporting the whole world as administrator-installed.
+
+    Arguments:
+      - uci -- EUci pointer, unused, kept for consistency with other facts
+
+    Returns:
+      - a dictionary with the following keys:
+        - count -- number of extra packages
+        - packages -- sorted list of extra package names
+    """
+    base = _read_apk_world(APK_WORLD_BASE)
+    current = _read_apk_world(APK_WORLD)
+    extras = sorted(current - base) if base else []
+    return {'count': len(extras), 'packages': extras}
 
 def fact_dhcp_server(uci: EUci):
     result = {

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1314,11 +1314,80 @@ def test_info_image_updates_available_current_newer():
 def test_info_image_updates_available_command_fails():
 	"""Test info_image_updates_available when command fails"""
 	u = EUci()
-	
+
 	mock_result = MagicMock()
 	mock_result.returncode = 1
 	mock_result.stdout = ''
-	
+
 	with patch('subprocess.run', return_value=mock_result):
 		result = inventory.info_image_updates_available(u)
 		assert result is False
+
+def test_fact_extra_packages_with_extras(tmp_path):
+	"""Test fact_extra_packages reports packages present in current world but not in base world"""
+	u = EUci()
+
+	base_file = tmp_path.joinpath('apk_world_base')
+	base_file.write_text("bash\nlibc\nnginx-ssl\n")
+
+	cur_file = tmp_path.joinpath('apk_world')
+	cur_file.write_text("bash\nlibc\nnginx-ssl\ncheckmk-agent\nnut-server\n")
+
+	with patch('nethsec.inventory.APK_WORLD', str(cur_file)), patch('nethsec.inventory.APK_WORLD_BASE', str(base_file)):
+		result = inventory.fact_extra_packages(u)
+		assert result == {'count': 2, 'packages': ['checkmk-agent', 'nut-server']}
+
+def test_fact_extra_packages_no_extras(tmp_path):
+	"""Test fact_extra_packages reports no extras when current and base worlds match"""
+	u = EUci()
+
+	base_file = tmp_path.joinpath('apk_world_base')
+	base_file.write_text("bash\nlibc\nnginx-ssl\n")
+
+	cur_file = tmp_path.joinpath('apk_world')
+	cur_file.write_text("bash\nlibc\nnginx-ssl\n")
+
+	with patch('nethsec.inventory.APK_WORLD', str(cur_file)), patch('nethsec.inventory.APK_WORLD_BASE', str(base_file)):
+		result = inventory.fact_extra_packages(u)
+		assert result == {'count': 0, 'packages': []}
+
+def test_fact_extra_packages_missing_base_world(tmp_path):
+	"""Test fact_extra_packages returns empty result when the base world file is missing"""
+	u = EUci()
+
+	base_file = tmp_path.joinpath('apk_world_base_missing')
+
+	cur_file = tmp_path.joinpath('apk_world')
+	cur_file.write_text("bash\nlibc\nnginx-ssl\ncheckmk-agent\n")
+
+	with patch('nethsec.inventory.APK_WORLD', str(cur_file)), patch('nethsec.inventory.APK_WORLD_BASE', str(base_file)):
+		result = inventory.fact_extra_packages(u)
+		assert result == {'count': 0, 'packages': []}
+
+def test_fact_extra_packages_strips_version_constraints(tmp_path):
+	"""Test fact_extra_packages strips version constraints before comparing package names"""
+	u = EUci()
+
+	base_file = tmp_path.joinpath('apk_world_base')
+	base_file.write_text("base-files=1711~f5dae5ece4\nlibc=1.2.5-r5\n")
+
+	cur_file = tmp_path.joinpath('apk_world')
+	cur_file.write_text("base-files=1712~aaaaaaaaaa\nlibc=1.2.6-r0\ncheckmk-agent\n")
+
+	with patch('nethsec.inventory.APK_WORLD', str(cur_file)), patch('nethsec.inventory.APK_WORLD_BASE', str(base_file)):
+		result = inventory.fact_extra_packages(u)
+		assert result == {'count': 1, 'packages': ['checkmk-agent']}
+
+def test_fact_extra_packages_ignores_noise_lines(tmp_path):
+	"""Test fact_extra_packages ignores blank lines, comments, and '!' lines in the current world"""
+	u = EUci()
+
+	base_file = tmp_path.joinpath('apk_world_base')
+	base_file.write_text("bash\nlibc\nnginx-ssl\n")
+
+	cur_file = tmp_path.joinpath('apk_world')
+	cur_file.write_text("bash\nlibc\nnginx-ssl\n\n# comment\n!conflictpkg\n")
+
+	with patch('nethsec.inventory.APK_WORLD', str(cur_file)), patch('nethsec.inventory.APK_WORLD_BASE', str(base_file)):
+		result = inventory.fact_extra_packages(u)
+		assert result == {'count': 0, 'packages': []}


### PR DESCRIPTION
Report the list of extra installed packages

New fact:

```json
"extra_packages": { "count": 2, "packages": ["checkmk-agent", "nut-server"] }
```

No change is needed in the nethsecurity repo: both `phonehome` and
`inventory` already collect every `fact_*` function automatically.

## How to test

On a device, install the new library, then:

```
cd /usr/lib/python3.13/site-packages/nethsec/inventory
wget https://raw.githubusercontent.com/NethServer/python3-nethsec/extra_packages/src/nethsec/inventory/__init__.py

phonehome | jq .facts.features.extra_packages   # count 0, no packages

apk add checkmk-agent nut-server
phonehome | jq .facts.features.extra_packages   # count 2, both packages, no deps

apk del checkmk-agent nut-server
phonehome | jq .facts.features.extra_packages   # count 0, no packages
```

To be merged after release of NethSecurity 8.8

